### PR TITLE
feat: Audio dubbing (voice-preserving, paid plans)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ GOOGLE_GENAI_USE_VERTEXAI=true
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 GOOGLE_CLOUD_LOCATION=global
 GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/vertex-sa.json
+# Dubbing source media bucket (public-read; Vertex transcribes from gs://, Modal fetches the reference).
+GCS_DUBBING_BUCKET=my-dubbing-bucket
+# Modal dubbing service URL — the exact URL `modal deploy` prints for the /dub
+# endpoint (each Modal web endpoint has its own dedicated hostname; no path is appended).
+MODAL_API_URL=https://your-workspace--creator-ai-dubbing-dub.modal.run
+# DUBBING_CREDIT_MULTIPLIER=15               # credits per second of source audio
 # Optional model overrides (defaults: gemini-3.5-flash / gemini-2.5-flash-image / gemini-embedding-001)
 # GEMINI_TEXT_MODEL=gemini-3.5-flash
 # GEMINI_IMAGE_MODEL=gemini-2.5-flash-image

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -23,6 +23,12 @@ GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 GOOGLE_CLOUD_LOCATION=global
 GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/vertex-sa.json
 GCS_SUBTITLE_BUCKET=my-subtitle-bucket
+# Public-read bucket dubbing source media is uploaded to (audio dubbing feature).
+GCS_DUBBING_BUCKET=my-dubbing-bucket
+# Modal dubbing service URL — the exact URL `modal deploy` prints for the /dub
+# endpoint (each Modal web endpoint has its own dedicated hostname; no path is appended).
+MODAL_API_URL=https://your-workspace--creator-ai-dubbing-dub.modal.run
+# DUBBING_CREDIT_MULTIPLIER=15   # credits charged per second of source audio
 # Optional model overrides (defaults: gemini-3.5-flash / gemini-2.5-flash-image / gemini-embedding-001)
 # GEMINI_TEXT_MODEL=gemini-3.5-flash
 # GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
@@ -36,6 +42,3 @@ LEMONSQUEEZY_WEBHOOK_SECRET=your-webhook-signing-secret
 # Email
 RESEND_API_KEY=your-resend-api-key
 ADMIN_NOTIFICATION_EMAIL=your-email@example.com
-
-# Audio Dubbing (Modal VoxCPM)
-MODAL_API_URL=https://your-workspace--voxcpm-dubbing-api-web.modal.run

--- a/apps/api/src/dubbing/dubbing.controller.ts
+++ b/apps/api/src/dubbing/dubbing.controller.ts
@@ -1,43 +1,140 @@
 import { Controller, Post, Body, Get, Delete, Param, Query, UseGuards, Req, Sse } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiBody } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiBody, ApiResponse } from '@nestjs/swagger';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import type { Observable } from 'rxjs';
 import { DubbingService } from './dubbing.service';
-import type { CreateDubInput } from '@repo/validation';
+import {
+  SignDubUploadSchema,
+  CreateDubSchema,
+  type SignDubUploadInput,
+  type CreateDubInput,
+} from '@repo/validation';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { createJobSSE } from '../common/sse';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
 
 @ApiTags('dubbing')
 @Controller('dubbing')
 export class DubbingController {
-  constructor(private readonly service: DubbingService) { }
+  constructor(
+    private readonly service: DubbingService,
+    @InjectQueue('dubbing') private readonly queue: Queue,
+  ) {}
+
+  @Get('access')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Whether the user may dub (Pro/Business/Scale)' })
+  async access(@Req() req: AuthRequest) {
+    return this.service.getAccess(req.user!.id);
+  }
+
+  @Post('sign-upload')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get a signed URL to upload source media to GCS',
+    description: 'Plan-gated (paid plans only). The browser PUTs the file to the returned uploadUrl, then calls POST /dubbing with the objectName.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['filename', 'contentType', 'fileSize', 'isVideo', 'durationSeconds'],
+      properties: {
+        filename: { type: 'string', maxLength: 200 },
+        contentType: { type: 'string', example: 'audio/mpeg', description: 'audio/* or video/*' },
+        fileSize: { type: 'integer', description: 'bytes; max 500MB' },
+        isVideo: { type: 'boolean' },
+        durationSeconds: { type: 'number', description: 'media duration; drives credit cost' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: '{ success, uploadUrl, objectName, contentType }' })
+  @ApiResponse({ status: 403, description: 'Free (Starter) plan or insufficient credits' })
+  async signUpload(
+    @Req() req: AuthRequest,
+    @Body(new ZodValidationPipe(SignDubUploadSchema)) body: SignDubUploadInput,
+  ) {
+    return this.service.signUpload(body, req.user!.id);
+  }
 
   @Post()
   @UseGuards(SupabaseAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Create dubbing project' })
+  @ApiOperation({
+    summary: 'Create a dubbing job from an uploaded object',
+    description: 'Verifies the GCS object, prechecks credits, inserts the project row and enqueues the worker. Follow progress via SSE /dubbing/status/{jobId}.',
+  })
   @ApiBody({
     schema: {
       type: 'object',
-      required: ['mediaUrl', 'targetLanguage', 'isVideo', 'mediaName'],
+      required: ['objectName', 'targetLanguage', 'isVideo', 'mediaName', 'durationSeconds'],
       properties: {
-        mediaUrl: { type: 'string', format: 'uri' },
-        targetLanguage: { type: 'string' },
+        objectName: { type: 'string', description: 'objectName returned by sign-upload' },
+        targetLanguage: { type: 'string', example: 'es', description: 'ISO code from supportedLanguages' },
         isVideo: { type: 'boolean' },
         mediaName: { type: 'string', maxLength: 100 },
+        durationSeconds: { type: 'number' },
       },
     },
   })
-  async create(@Req() req: AuthRequest, @Body() dto: CreateDubInput) {
-    return this.service.createDub(dto, req.user!.id);
+  @ApiResponse({ status: 201, description: '{ projectId, jobId }' })
+  @ApiResponse({ status: 403, description: 'Free plan, foreign object, or insufficient credits' })
+  async create(
+    @Req() req: AuthRequest,
+    @Body(new ZodValidationPipe(CreateDubSchema)) body: CreateDubInput,
+  ) {
+    return this.service.createDub(body, req.user!.id);
   }
 
-  @Sse('status/:projectId')
+  @Post(':id/regenerate')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({
-    summary: 'SSE: dubbing status for project',
+    summary: 'Regenerate a dub from its original media',
+    description: 'Re-runs the same source (reused from GCS) with the same target language, resetting the project in place and enqueuing a fresh job. Charges credits like a new dub.',
+  })
+  @ApiParam({ name: 'id', description: 'dubbing project_id' })
+  @ApiResponse({ status: 201, description: '{ projectId, jobId }' })
+  @ApiResponse({ status: 400, description: 'Original media no longer available' })
+  @ApiResponse({ status: 403, description: 'Free plan or insufficient credits' })
+  async regenerate(@Req() req: AuthRequest, @Param('id') id: string) {
+    return this.service.regenerateDub(req.user!.id, id);
+  }
+
+  @Post('stop/:jobId')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Stop or cancel a dubbing job',
+    description: 'Queued jobs are removed immediately; active jobs are flagged and abort between pipeline stages (no credits charged).',
+  })
+  @ApiParam({ name: 'jobId', description: 'BullMQ job id returned by POST /dubbing' })
+  @ApiResponse({ status: 201, description: '{ message }' })
+  async stop(@Req() req: AuthRequest, @Param('jobId') jobId: string) {
+    return this.service.stopDub(req.user!.id, jobId);
+  }
+
+  @Sse('status/:jobId')
+  @ApiOperation({
+    summary: 'SSE: dubbing job status',
     description: 'No Bearer required on this route in the current implementation.',
   })
-  @ApiParam({ name: 'projectId' })
-  status(@Param('projectId') projectId: string) {
-    return this.service.streamDubbingStatus(projectId);
+  @ApiParam({ name: 'jobId' })
+  status(@Param('jobId') jobId: string, @Req() req: AuthRequest): Observable<MessageEvent> {
+    return createJobSSE({
+      queue: this.queue,
+      jobId,
+      req,
+      getMessages: {
+        active: 'Dubbing in progress...',
+        completed: 'Dubbing complete!',
+        failed: 'Dubbing failed',
+      },
+      extractResult: (job) => ({ dubbedUrl: job.returnvalue?.dubbedUrl }),
+    });
   }
 
   @Get()

--- a/apps/api/src/dubbing/dubbing.module.ts
+++ b/apps/api/src/dubbing/dubbing.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { BullModule } from '@nestjs/bullmq';
 import { DubbingService } from './dubbing.service';
 import { DubbingController } from './dubbing.controller';
 import { SupabaseModule } from '../supabase/supabase.module';
 
 @Module({
-  imports: [SupabaseModule],
+  imports: [SupabaseModule, ConfigModule, BullModule.registerQueue({ name: 'dubbing' })],
   providers: [DubbingService],
   controllers: [DubbingController],
 })
-export class DubbingModule { }
+export class DubbingModule {}

--- a/apps/api/src/dubbing/dubbing.service.spec.ts
+++ b/apps/api/src/dubbing/dubbing.service.spec.ts
@@ -1,0 +1,174 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { getQueueToken } from '@nestjs/bullmq';
+import { DubbingService } from './dubbing.service';
+import { SupabaseService } from '../supabase/supabase.service';
+import { DUBBING_CANCEL_PREFIX } from '@repo/validation';
+
+jest.mock('../utils', () => ({
+  getSignedUploadUrl: jest.fn().mockResolvedValue('https://signed-upload-url'),
+  gcsObjectMetadata: jest.fn().mockResolvedValue({ size: 1000, contentType: 'audio/mpeg' }),
+  gcsPublicUrl: jest.fn(() => 'https://storage.googleapis.com/dub-bucket/obj'),
+  gcsUri: jest.fn(() => 'gs://dub-bucket/obj'),
+  deleteGcsObject: jest.fn().mockResolvedValue(undefined),
+  getDubbingBucketName: jest.fn(() => 'dub-bucket'),
+}));
+
+/** Chainable supabase query mock: every builder method returns the chain; awaiting it
+ *  (or .single()/.maybeSingle()) resolves to the configured result. */
+function chain(result: unknown) {
+  const c: any = {};
+  for (const m of ['select', 'eq', 'in', 'order', 'limit', 'insert', 'update', 'delete']) {
+    c[m] = jest.fn(() => c);
+  }
+  c.single = jest.fn(() => Promise.resolve(result));
+  c.maybeSingle = jest.fn(() => Promise.resolve(result));
+  c.then = (res: any, rej: any) => Promise.resolve(result).then(res, rej);
+  return c;
+}
+
+const USER = 'user-1';
+
+describe('DubbingService', () => {
+  let service: DubbingService;
+  let tables: Record<string, any>;
+  let queue: { add: jest.Mock; getJob: jest.Mock; client: Promise<any> };
+  let redis: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
+
+  function planResult(name: string | null) {
+    return { data: name ? { plans: { name } } : null };
+  }
+
+  async function build(overrides: Partial<Record<string, any>> = {}) {
+    tables = {
+      subscriptions: chain(planResult('Creator')),
+      profiles: chain({ data: { credits: 10_000 }, error: null }),
+      dubbing_projects: chain({ data: null, error: null }),
+      ...overrides,
+    };
+    redis = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
+    queue = { add: jest.fn(), getJob: jest.fn(), client: Promise.resolve(redis) };
+
+    const mockSupabase = { getClient: () => ({ from: (t: string) => tables[t] }) };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DubbingService,
+        { provide: SupabaseService, useValue: mockSupabase },
+        { provide: ConfigService, useValue: { get: (k: string) => (k === 'GCS_DUBBING_BUCKET' ? 'dub-bucket' : undefined) } },
+        { provide: getQueueToken('dubbing'), useValue: queue },
+      ],
+    }).compile();
+    service = module.get(DubbingService);
+  }
+
+  describe('getAccess (plan gate)', () => {
+    it.each(['Creator', 'Pro', 'Business', 'Scale'])('allows the paid %s plan', async (plan) => {
+      await build({ subscriptions: chain(planResult(plan)) });
+      await expect(service.getAccess(USER)).resolves.toMatchObject({ allowed: true, plan });
+    });
+
+    it('denies Starter (free) and users with no subscription', async () => {
+      await build({ subscriptions: chain(planResult('Starter')) });
+      await expect(service.getAccess(USER)).resolves.toMatchObject({ allowed: false });
+
+      await build({ subscriptions: chain(planResult(null)) });
+      await expect(service.getAccess(USER)).resolves.toMatchObject({ allowed: false });
+    });
+  });
+
+  describe('signUpload', () => {
+    const input = { filename: 'a.mp3', contentType: 'audio/mpeg', fileSize: 1000, isVideo: false, durationSeconds: 30 };
+
+    it('rejects Starter with ForbiddenException', async () => {
+      await build({ subscriptions: chain(planResult('Starter')) });
+      await expect(service.signUpload(input, USER)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects files over 500MB', async () => {
+      await build();
+      await expect(
+        service.signUpload({ ...input, fileSize: 501 * 1024 * 1024 }, USER),
+      ).rejects.toThrow(PayloadTooLargeException);
+    });
+
+    it('returns a signed URL scoped to the user prefix for a paid plan', async () => {
+      await build();
+      const res = await service.signUpload(input, USER);
+      expect(res.uploadUrl).toBe('https://signed-upload-url');
+      expect(res.objectName.startsWith(`${USER}/dubbing/`)).toBe(true);
+    });
+  });
+
+  describe('createDub', () => {
+    const input = {
+      objectName: `${USER}/dubbing/123_a.mp3`,
+      targetLanguage: 'es',
+      isVideo: false,
+      mediaName: 'My clip',
+      durationSeconds: 30,
+    };
+
+    it("rejects an object outside the user's prefix", async () => {
+      await build();
+      await expect(
+        service.createDub({ ...input, objectName: 'other-user/dubbing/x.mp3' }, USER),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects when credits are below the floor', async () => {
+      await build({ profiles: chain({ data: { credits: 0 }, error: null }) });
+      await expect(service.createDub(input, USER)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('inserts the project and enqueues the worker job', async () => {
+      await build();
+      const res = await service.createDub(input, USER);
+      expect(res.projectId).toBeTruthy();
+      expect(res.jobId).toMatch(/^dubbing-user-1-/);
+      expect(queue.add).toHaveBeenCalledWith(
+        'dubbing',
+        expect.objectContaining({ userId: USER, targetLanguage: 'es', durationSeconds: 30 }),
+        expect.objectContaining({ jobId: res.jobId }),
+      );
+    });
+  });
+
+  describe('stopDub (cancellation)', () => {
+    it('404s when the job does not exist or belongs to someone else', async () => {
+      await build();
+      queue.getJob.mockResolvedValue(null);
+      await expect(service.stopDub(USER, 'nope')).rejects.toThrow(NotFoundException);
+
+      queue.getJob.mockResolvedValue({ data: { userId: 'other' } });
+      await expect(service.stopDub(USER, 'job-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('removes a waiting job and marks the row failed', async () => {
+      await build();
+      const remove = jest.fn();
+      queue.getJob.mockResolvedValue({
+        data: { userId: USER, projectId: 'p-1' },
+        getState: () => Promise.resolve('waiting'),
+        remove,
+      });
+      const res = await service.stopDub(USER, 'job-1');
+      expect(remove).toHaveBeenCalled();
+      expect(tables.dubbing_projects.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failed', error_message: 'Cancelled by user' }),
+      );
+      expect(res.message).toBe('Dubbing cancelled');
+    });
+
+    it('sets the Redis cancel flag for an active job', async () => {
+      await build();
+      queue.getJob.mockResolvedValue({
+        data: { userId: USER, projectId: 'p-1' },
+        getState: () => Promise.resolve('active'),
+      });
+      const res = await service.stopDub(USER, 'job-1');
+      expect(redis.set).toHaveBeenCalledWith(`${DUBBING_CANCEL_PREFIX}job-1`, '1', 'EX', 3600);
+      expect(res.message).toBe('Cancellation requested');
+    });
+  });
+});

--- a/apps/api/src/dubbing/dubbing.service.ts
+++ b/apps/api/src/dubbing/dubbing.service.ts
@@ -3,22 +3,34 @@ import {
   Logger,
   BadRequestException,
   ForbiddenException,
+  NotFoundException,
   InternalServerErrorException,
+  PayloadTooLargeException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Observable, interval, switchMap, map, from, takeWhile } from 'rxjs';
-import { SupabaseService } from '../supabase/supabase.service';
-import type { CreateDubInput, DubResponse, DubbingProgress } from '@repo/validation';
-import { calculateDubbingCredits, hasEnoughCredits } from '@repo/validation';
-import { createGoogleAI, GEMINI_TEXT_MODEL, fetchVideoAsBuffer, configureFFmpeg } from '../utils';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
 import * as crypto from 'crypto';
-import * as path from 'path';
-import * as os from 'os';
-import * as fs from 'fs/promises';
+import { SupabaseService } from '../supabase/supabase.service';
+import type { CreateDubInput, SignDubUploadInput, DubResponse } from '@repo/validation';
+import {
+  canDub,
+  hasEnoughCredits,
+  getMinimumCreditsForDubbing,
+  DUBBING_CREDIT_MULTIPLIER,
+  DUBBING_CANCEL_PREFIX,
+} from '@repo/validation';
+import {
+  getSignedUploadUrl,
+  gcsObjectMetadata,
+  gcsPublicUrl,
+  gcsUri,
+  deleteGcsObject,
+  getDubbingBucketName,
+} from '../utils';
 
-const MIN_DUBBING_CREDITS = 10;
-// Vertex AI takes media bytes inline (no Files API). base64 inflates size ~33%.
-const MAX_INLINE_BYTES = 50 * 1024 * 1024; // 50MB raw → ~67MB base64
+// Dubbing input is usually a short clip, but a video can be large — cap generously.
+const MAX_DUB_UPLOAD_BYTES = 500 * 1024 * 1024; // 500MB
 
 @Injectable()
 export class DubbingService {
@@ -27,57 +39,256 @@ export class DubbingService {
   constructor(
     private readonly supabaseService: SupabaseService,
     private readonly configService: ConfigService,
+    @InjectQueue('dubbing') private readonly queue: Queue,
   ) {}
 
   private get supabase() {
     return this.supabaseService.getClient();
   }
 
-  async createDub(input: CreateDubInput, userId: string): Promise<{ projectId: string }> {
-    const { data: profile } = await this.supabase
+  /** Dedicated dubbing bucket (GCS_DUBBING_BUCKET) — separate from subtitles. */
+  private get bucket(): string {
+    return getDubbingBucketName(this.configService);
+  }
+
+  /** The active plan is the most-recent active subscription (same source as BillingService). */
+  private async getActivePlanName(userId: string): Promise<string | null> {
+    const { data: subscription } = await this.supabase
+      .from('subscriptions')
+      .select('plans(name)')
+      .eq('user_id', userId)
+      .in('status', ['active', 'on_trial', 'past_due'])
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    return (subscription?.plans as { name?: string } | null)?.name ?? null;
+  }
+
+  /** Lightweight gate check for the UI — form vs. upgrade card. */
+  async getAccess(userId: string) {
+    const planName = await this.getActivePlanName(userId);
+    return { success: true, allowed: canDub(planName), plan: planName };
+  }
+
+  private sanitizeFileName(value: string): string {
+    return value.replace(/[^\w.\-]/g, '_');
+  }
+
+  private getEnvNumber(key: string, fallback: number): number {
+    const raw = process.env[key];
+    const parsed = raw ? Number(raw) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  /**
+   * Step 1: plan-gate, size-check, then issue a signed URL the browser PUTs the
+   * source media straight to GCS with — the API never touches the bytes.
+   */
+  async signUpload(input: SignDubUploadInput, userId: string) {
+    const planName = await this.getActivePlanName(userId);
+    if (!canDub(planName)) {
+      throw new ForbiddenException('Dubbing is available on all paid plans. Please upgrade from Starter to dub your media.');
+    }
+
+    if (input.fileSize > MAX_DUB_UPLOAD_BYTES) {
+      throw new PayloadTooLargeException(
+        `File exceeds the ${Math.round(MAX_DUB_UPLOAD_BYTES / 1024 / 1024)}MB dubbing upload limit.`,
+      );
+    }
+
+    const safeName = this.sanitizeFileName(input.filename);
+    const objectName = `${userId}/dubbing/${Date.now()}_${safeName}`;
+    const uploadUrl = await getSignedUploadUrl(this.configService, objectName, input.contentType, this.bucket);
+    return { success: true, uploadUrl, objectName, contentType: input.contentType };
+  }
+
+  /**
+   * Step 2: verify the uploaded object (ownership + real size), create the job row,
+   * and enqueue the dubbing worker. The worker deducts the real (duration-based) cost.
+   */
+  async createDub(input: CreateDubInput, userId: string): Promise<{ projectId: string; jobId: string }> {
+    const { objectName, targetLanguage, isVideo, mediaName, durationSeconds } = input;
+
+    const planName = await this.getActivePlanName(userId);
+    if (!canDub(planName)) {
+      throw new ForbiddenException('Dubbing is available on all paid plans. Please upgrade from Starter to dub your media.');
+    }
+
+    // The signed URL was scoped to this user's prefix — refuse someone else's object.
+    if (!objectName.startsWith(`${userId}/`)) {
+      throw new ForbiddenException('Object does not belong to user');
+    }
+
+    let size: number;
+    let contentType: string;
+    try {
+      ({ size, contentType } = await gcsObjectMetadata(this.configService, objectName, this.bucket));
+    } catch {
+      throw new BadRequestException('Uploaded file not found in storage');
+    }
+    if (size > MAX_DUB_UPLOAD_BYTES) {
+      await deleteGcsObject(this.configService, objectName, this.bucket).catch(() => null);
+      throw new PayloadTooLargeException('Uploaded file exceeds the dubbing upload limit.');
+    }
+
+    // Precheck the floor before enqueuing — the worker deducts the duration-based cost.
+    const multiplier = this.getEnvNumber('DUBBING_CREDIT_MULTIPLIER', DUBBING_CREDIT_MULTIPLIER);
+    const { data: profile, error: profileError } = await this.supabase
       .from('profiles')
       .select('credits')
       .eq('user_id', userId)
       .single();
-
-    if (!profile || !hasEnoughCredits(profile.credits, MIN_DUBBING_CREDITS)) {
-      throw new ForbiddenException('Insufficient credits for dubbing.');
+    if (profileError || !profile) throw new NotFoundException('Profile not found');
+    if (!hasEnoughCredits(profile.credits, getMinimumCreditsForDubbing(multiplier))) {
+      throw new ForbiddenException('Insufficient credits. Please upgrade your plan or earn more credits.');
     }
 
-    const modalUrl = this.configService.get<string>('MODAL_API_URL');
-    if (!modalUrl) {
-      throw new BadRequestException('Dubbing service is not configured');
-    }
-
+    const publicUrl = gcsPublicUrl(this.configService, objectName, this.bucket);
+    const inputGsUri = gcsUri(this.configService, objectName, this.bucket);
     const projectId = crypto.randomUUID();
 
-    const { error } = await this.supabase.from('dubbing_projects').insert({
+    const { error: insertError } = await this.supabase.from('dubbing_projects').insert({
       project_id: projectId,
       user_id: userId,
-      original_media_url: input.mediaUrl,
-      target_language: input.targetLanguage,
-      is_video: input.isVideo,
-      media_name: input.mediaName,
-      status: 'dubbing',
+      original_media_url: publicUrl,
+      input_url: publicUrl,
+      input_gs_uri: inputGsUri,
+      target_language: targetLanguage,
+      is_video: isVideo,
+      media_name: mediaName,
+      duration_seconds: durationSeconds,
+      status: 'queued',
       credits_consumed: 0,
     });
+    if (insertError) {
+      await deleteGcsObject(this.configService, objectName, this.bucket).catch(() => null);
+      this.logger.error(`Failed to create dubbing project for user ${userId}: ${insertError.message}`);
+      throw new InternalServerErrorException('Failed to create dubbing project');
+    }
 
-    if (error) throw new InternalServerErrorException('Failed to create dubbing project');
+    const bullJobId = `dubbing-${userId}-${Date.now()}`;
+    await this.queue.add(
+      'dubbing',
+      {
+        userId,
+        projectId,
+        bullJobId,
+        inputGsUri,
+        inputUrl: publicUrl,
+        mimeType: contentType,
+        isVideo,
+        targetLanguage,
+        durationSeconds,
+      },
+      { jobId: bullJobId },
+    );
 
-    void this.processDub(projectId, input, userId, modalUrl);
+    await this.supabase.from('dubbing_projects').update({ job_id: bullJobId }).eq('project_id', projectId);
 
-    return { projectId };
+    return { projectId, jobId: bullJobId };
   }
 
-  streamDubbingStatus(projectId: string): Observable<MessageEvent> {
-    return interval(2500).pipe(
-      switchMap(() => from(this.getProgress(projectId))),
-      map((progress) => ({ data: JSON.stringify(progress) }) as MessageEvent),
-      takeWhile((event) => {
-        const data: DubbingProgress = JSON.parse((event as MessageEvent & { data: string }).data);
-        return !data.finished;
-      }, true),
+  /**
+   * Re-run a completed/failed dub with the SAME input — reuses the source object
+   * still in GCS (no re-upload), resets the row and enqueues a fresh job in place.
+   */
+  async regenerateDub(userId: string, projectId: string): Promise<{ projectId: string; jobId: string }> {
+    const planName = await this.getActivePlanName(userId);
+    if (!canDub(planName)) {
+      throw new ForbiddenException('Dubbing is available on all paid plans. Please upgrade from Starter to dub your media.');
+    }
+
+    const { data: row, error } = await this.supabase
+      .from('dubbing_projects')
+      .select('input_gs_uri, input_url, target_language, is_video, duration_seconds')
+      .eq('user_id', userId)
+      .eq('project_id', projectId)
+      .single();
+    if (error || !row) throw new NotFoundException('Dubbing project not found');
+    if (!row.input_gs_uri || !row.input_url || !row.duration_seconds) {
+      throw new BadRequestException('This dub is missing its source media and cannot be regenerated.');
+    }
+
+    // The stored source must still exist in GCS — and gives us its content type.
+    const objectName = String(row.input_gs_uri).split('/').slice(3).join('/');
+    let contentType: string;
+    try {
+      ({ contentType } = await gcsObjectMetadata(this.configService, objectName, this.bucket));
+    } catch {
+      throw new BadRequestException('The original media is no longer available. Please create a new dub.');
+    }
+
+    const multiplier = this.getEnvNumber('DUBBING_CREDIT_MULTIPLIER', DUBBING_CREDIT_MULTIPLIER);
+    const { data: profile, error: profileError } = await this.supabase
+      .from('profiles')
+      .select('credits')
+      .eq('user_id', userId)
+      .single();
+    if (profileError || !profile) throw new NotFoundException('Profile not found');
+    if (!hasEnoughCredits(profile.credits, getMinimumCreditsForDubbing(multiplier))) {
+      throw new ForbiddenException('Insufficient credits. Please upgrade your plan or earn more credits.');
+    }
+
+    // Reset the row in place so the same detail page reflects the new run.
+    await this.supabase
+      .from('dubbing_projects')
+      .update({ status: 'queued', dubbed_url: null, error_message: null, credits_consumed: 0 })
+      .eq('project_id', projectId)
+      .eq('user_id', userId);
+
+    const bullJobId = `dubbing-${userId}-${Date.now()}`;
+    await this.queue.add(
+      'dubbing',
+      {
+        userId,
+        projectId,
+        bullJobId,
+        inputGsUri: row.input_gs_uri,
+        inputUrl: row.input_url,
+        mimeType: contentType,
+        isVideo: row.is_video,
+        targetLanguage: row.target_language,
+        durationSeconds: Number(row.duration_seconds),
+      },
+      { jobId: bullJobId },
     );
+
+    await this.supabase.from('dubbing_projects').update({ job_id: bullJobId }).eq('project_id', projectId);
+
+    return { projectId, jobId: bullJobId };
+  }
+
+  /**
+   * Mid-run cancellation (train-ai pattern): a queued job is removed outright;
+   * an active one gets a Redis flag the worker checks between pipeline stages.
+   */
+  async stopDub(userId: string, jobId: string): Promise<{ message: string }> {
+    const job = await this.queue.getJob(jobId);
+    if (!job || job.data?.userId !== userId) {
+      throw new NotFoundException('Job not found');
+    }
+
+    const state = await job.getState();
+
+    if (state === 'waiting' || state === 'delayed') {
+      await job.remove();
+      // Mark the row too — otherwise it sits 'queued' forever.
+      await this.supabase
+        .from('dubbing_projects')
+        .update({ status: 'failed', error_message: 'Cancelled by user' })
+        .eq('project_id', job.data.projectId)
+        .eq('user_id', userId);
+      return { message: 'Dubbing cancelled' };
+    }
+
+    if (state === 'active') {
+      const client = await this.queue.client;
+      await client.set(`${DUBBING_CANCEL_PREFIX}${jobId}`, '1', 'EX', 3600);
+      return { message: 'Cancellation requested' };
+    }
+
+    return { message: 'Job already finished' };
   }
 
   async listDubs(userId: string, pageSize = 100) {
@@ -118,174 +329,24 @@ export class DubbingService {
   }
 
   async deleteDub(userId: string, projectId: string): Promise<void> {
-    const { error } = await this.supabase
+    const { data, error } = await this.supabase
       .from('dubbing_projects')
       .delete()
       .eq('user_id', userId)
-      .eq('project_id', projectId);
-
-    if (error) throw new BadRequestException('Dub not found or access denied');
-  }
-
-  // --- Background pipeline ---
-
-  private async getProgress(projectId: string): Promise<DubbingProgress> {
-    const { data } = await this.supabase
-      .from('dubbing_projects')
-      .select('status, credits_consumed')
       .eq('project_id', projectId)
+      .select('input_gs_uri')
       .single();
 
-    if (!data) {
-      return { state: 'failed', progress: 0, message: 'Project not found', finished: true };
+    if (error) throw new BadRequestException('Dub not found or access denied');
+
+    // Clean up the source object in GCS (output WAV is left to Supabase lifecycle).
+    if (data?.input_gs_uri) {
+      const objectName = String(data.input_gs_uri).split('/').slice(3).join('/');
+      if (objectName) {
+        await deleteGcsObject(this.configService, objectName, this.bucket).catch((e) =>
+          this.logger.error(`Failed to delete GCS object ${objectName}`, e),
+        );
+      }
     }
-
-    switch (data.status) {
-      case 'dubbing':
-        return { state: 'processing', progress: 30, message: 'Transcribing and translating audio...' };
-      case 'cloning':
-        return { state: 'processing', progress: 65, message: 'Generating dubbed audio...' };
-      case 'dubbed':
-        return { state: 'completed', progress: 100, message: 'Dubbing complete!', finished: true, creditsUsed: data.credits_consumed };
-      case 'failed':
-        return { state: 'failed', progress: 0, message: 'Dubbing failed. Please try again.', finished: true };
-      default:
-        return { state: 'processing', progress: 15, message: 'Starting...' };
-    }
-  }
-
-  private async processDub(projectId: string, input: CreateDubInput, userId: string, modalUrl: string): Promise<void> {
-    try {
-      const mediaBuffer = await fetchVideoAsBuffer(input.mediaUrl);
-
-      const referenceAudio = input.isVideo
-        ? await this.extractAudio(mediaBuffer)
-        : mediaBuffer;
-
-      const translatedText = await this.transcribeAndTranslate(mediaBuffer, input.isVideo, input.targetLanguage);
-
-      await this.updateStatus(projectId, 'cloning');
-
-      const dubbedAudio = await this.callModalDub(modalUrl, translatedText, referenceAudio);
-
-      const filePath = `dubbed/${projectId}.wav`;
-      const { error: uploadError } = await this.supabase.storage
-        .from('dubbing_media')
-        .upload(filePath, dubbedAudio, { contentType: 'audio/wav', upsert: true });
-
-      if (uploadError) throw new Error(`Storage upload failed: ${uploadError.message}`);
-
-      const { data: urlData } = this.supabase.storage
-        .from('dubbing_media')
-        .getPublicUrl(filePath);
-
-      const creditsConsumed = calculateDubbingCredits({ externalCreditsUsed: 1 });
-
-      await this.supabase.rpc('update_user_credits', {
-        user_uuid: userId,
-        credit_change: -creditsConsumed,
-      });
-
-      await this.supabase
-        .from('dubbing_projects')
-        .update({ status: 'dubbed', dubbed_url: urlData.publicUrl, credits_consumed: creditsConsumed })
-        .eq('project_id', projectId);
-
-      this.logger.log(`Dubbing complete: ${projectId}`);
-    } catch (error) {
-      this.logger.error(`Dubbing failed: ${projectId}`, error);
-      await this.updateStatus(projectId, 'failed');
-    }
-  }
-
-  private async updateStatus(projectId: string, status: string) {
-    await this.supabase
-      .from('dubbing_projects')
-      .update({ status })
-      .eq('project_id', projectId);
-  }
-
-  // --- Gemini transcription + translation ---
-
-  private async transcribeAndTranslate(mediaBuffer: Buffer, isVideo: boolean, targetLanguage: string): Promise<string> {
-    const ai = await createGoogleAI(this.configService);
-    const mimeType = isVideo ? 'video/mp4' : 'audio/mpeg';
-
-    if (mediaBuffer.length > MAX_INLINE_BYTES) {
-      throw new BadRequestException('Media file is too large to process. Please use a shorter or smaller file.');
-    }
-
-    // Vertex AI: send media bytes inline (the Files API is not available on Vertex).
-    const result = await ai.models.generateContent({
-      model: GEMINI_TEXT_MODEL,
-      contents: [{
-        role: 'user',
-        parts: [
-          { text: `Transcribe the spoken audio from this file, then translate the full transcript into ${targetLanguage}. Return ONLY the translated text as a single continuous paragraph. No timestamps, no formatting, no labels — just the translated text.` },
-          { inlineData: { data: mediaBuffer.toString('base64'), mimeType } },
-        ],
-      }],
-    });
-
-    const text = result.text?.trim();
-    if (!text) throw new Error('Empty transcription/translation result from Gemini');
-    return text;
-  }
-
-  // --- Audio extraction (video → audio via ffmpeg) ---
-
-  private async extractAudio(videoBuffer: Buffer): Promise<Buffer> {
-    const videoPath = path.join(os.tmpdir(), `vid_${Date.now()}.mp4`);
-    const audioPath = path.join(os.tmpdir(), `aud_${Date.now()}.wav`);
-    await fs.writeFile(videoPath, videoBuffer);
-
-    try {
-      const ffmpeg = configureFFmpeg();
-      await new Promise<void>((resolve, reject) => {
-        ffmpeg(videoPath)
-          .noVideo()
-          .audioCodec('pcm_s16le')
-          .audioFrequency(16000)
-          .audioChannels(1)
-          .format('wav')
-          .on('end', () => resolve())
-          .on('error', (err: Error) => reject(err))
-          .save(audioPath);
-      });
-      return await fs.readFile(audioPath);
-    } finally {
-      await Promise.allSettled([fs.unlink(videoPath), fs.unlink(audioPath)]);
-    }
-  }
-
-  // --- Modal VoxCPM API call ---
-
-  private async callModalDub(modalUrl: string, text: string, referenceAudio: Buffer): Promise<Buffer> {
-    const formData = new FormData();
-    formData.append('text', text);
-    formData.append('reference', new Blob([new Uint8Array(referenceAudio)]), 'reference.wav');
-
-    const response = await fetch(`${modalUrl}/dub`, {
-      method: 'POST',
-      body: formData,
-    });
-
-    if (!response.ok) {
-      const errBody = await response.text().catch(() => 'Unknown error');
-      throw new Error(`Modal API error ${response.status}: ${errBody}`);
-    }
-
-    const contentType = response.headers.get('content-type') || '';
-
-    if (contentType.includes('audio') || contentType.includes('octet-stream')) {
-      return Buffer.from(await response.arrayBuffer());
-    }
-
-    const json = await response.json() as Record<string, unknown>;
-    for (const key of ['audio_base64', 'audio', 'data']) {
-      if (typeof json[key] === 'string') return Buffer.from(json[key] as string, 'base64');
-    }
-
-    throw new Error('Unexpected response format from Modal dubbing API');
   }
 }

--- a/apps/api/src/utils/gcs.ts
+++ b/apps/api/src/utils/gcs.ts
@@ -34,12 +34,23 @@ function getBucketName(configService: ConfigService): string {
   return bucket;
 }
 
-export function gcsPublicUrl(configService: ConfigService, objectName: string): string {
-  return `https://storage.googleapis.com/${getBucketName(configService)}/${objectName}`;
+/** Dubbing keeps its own bucket so retention/cleanup can diverge from subtitles. */
+export function getDubbingBucketName(configService: ConfigService): string {
+  const bucket = configService.get<string>('GCS_DUBBING_BUCKET');
+  if (!bucket) {
+    throw new Error('GCS_DUBBING_BUCKET is not configured');
+  }
+  return bucket;
 }
 
-export function gcsUri(configService: ConfigService, objectName: string): string {
-  return `gs://${getBucketName(configService)}/${objectName}`;
+// The helpers below default to the subtitle bucket; pass `bucket` (e.g.
+// getDubbingBucketName(...)) to target another one.
+export function gcsPublicUrl(configService: ConfigService, objectName: string, bucket?: string): string {
+  return `https://storage.googleapis.com/${bucket ?? getBucketName(configService)}/${objectName}`;
+}
+
+export function gcsUri(configService: ConfigService, objectName: string, bucket?: string): string {
+  return `gs://${bucket ?? getBucketName(configService)}/${objectName}`;
 }
 
 /**
@@ -52,10 +63,11 @@ export async function getSignedUploadUrl(
   configService: ConfigService,
   objectName: string,
   contentType: string,
+  bucket?: string,
 ): Promise<string> {
   const storage = await getStorage(configService);
   const [url] = await storage
-    .bucket(getBucketName(configService))
+    .bucket(bucket ?? getBucketName(configService))
     .file(objectName)
     .getSignedUrl({
       version: 'v4',
@@ -70,19 +82,20 @@ export async function getSignedUploadUrl(
 export async function gcsObjectMetadata(
   configService: ConfigService,
   objectName: string,
+  bucket?: string,
 ): Promise<{ size: number; contentType: string }> {
   const storage = await getStorage(configService);
   const [meta] = await storage
-    .bucket(getBucketName(configService))
+    .bucket(bucket ?? getBucketName(configService))
     .file(objectName)
     .getMetadata();
   return { size: Number(meta.size ?? 0), contentType: meta.contentType ?? 'application/octet-stream' };
 }
 
-export async function deleteGcsObject(configService: ConfigService, objectName: string): Promise<void> {
+export async function deleteGcsObject(configService: ConfigService, objectName: string, bucket?: string): Promise<void> {
   const storage = await getStorage(configService);
   await storage
-    .bucket(getBucketName(configService))
+    .bucket(bucket ?? getBucketName(configService))
     .file(objectName)
     .delete({ ignoreNotFound: true });
 }

--- a/apps/web/app/dashboard/dubbing/[id]/page.tsx
+++ b/apps/web/app/dashboard/dubbing/[id]/page.tsx
@@ -2,11 +2,16 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { useRouter, useParams } from "next/navigation"
+import { motion } from "motion/react"
 import { Button } from "@repo/ui/button"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@repo/ui/card"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@repo/ui/card"
 import { Label } from "@repo/ui/label"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@repo/ui/tooltip"
 import { toast } from "sonner"
-import { ArrowLeft, Download, Loader2, Trash2, CheckCircle2, Languages, Video, Music } from "lucide-react"
+import {
+  ArrowLeft, Download, Loader2, Trash2, CheckCircle2, Languages, Video, Music,
+  XCircle, RotateCw, Coins, CalendarDays, type LucideIcon,
+} from "lucide-react"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,12 +24,33 @@ import {
   AlertDialogFooter,
 } from "@repo/ui/alert-dialog"
 import { useSupabase } from "@/components/supabase-provider"
-import { getDubbing, deleteDubbing } from "@/lib/api/getDubbings"
+import { getDubbing, deleteDubbing, regenerateDubbing } from "@/lib/api/getDubbings"
 import { DubResponse, supportedLanguages } from "@repo/validation"
 import { downloadFile } from "@/lib/download"
+import { DubbingMediaPlayer } from "@/components/dashboard/dubbing/DubbingMediaPlayer"
 
 function getLanguageLabel(code: string): string {
   return supportedLanguages.find((l) => l.value === code)?.label ?? code
+}
+
+/** Glassy stat card — mirrors the main dashboard's Quick Actions card design. */
+function StatCard({ icon: Icon, label, value, iconClassName }: {
+  icon: LucideIcon
+  label: string
+  value: string
+  iconClassName?: string
+}) {
+  return (
+    <div className="group bg-white/70 dark:bg-slate-900/60 backdrop-blur-md border border-white/60 dark:border-slate-800/50 rounded-2xl p-5 flex items-start gap-4 hover:shadow-[0_8px_30px_rgba(168,85,247,0.12)] hover:-translate-y-1 hover:border-purple-500/50 transition-all duration-300">
+      <div className={`w-10 h-10 rounded-lg bg-slate-100/80 dark:bg-slate-800 flex items-center justify-center text-slate-500 dark:text-slate-400 group-hover:text-purple-600 dark:group-hover:text-purple-400 group-hover:bg-purple-500/10 transition-all duration-300 group-hover:scale-110 shrink-0 ${iconClassName ?? ""}`}>
+        <Icon className="h-5 w-5" />
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+        <p className="font-semibold text-slate-900 dark:text-slate-50 truncate">{value}</p>
+      </div>
+    </div>
+  )
 }
 
 export default function DubbingDetailPage() {
@@ -37,6 +63,7 @@ export default function DubbingDetailPage() {
   const [loading, setLoading] = useState(true)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isDownloading, setIsDownloading] = useState(false)
+  const [isRegenerating, setIsRegenerating] = useState(false)
 
   useEffect(() => {
     const fetchDubbing = async () => {
@@ -64,26 +91,47 @@ export default function DubbingDetailPage() {
     fetchDubbing()
   }, [projectId, session?.access_token, router])
 
+  // Poll while a job is in flight (queued/processing/cloning) — no SSE on this page.
+  const status = dubbing?.status
+  useEffect(() => {
+    if (!session?.access_token) return
+    if (!status || status === "completed" || status === "failed") return
+    const iv = setInterval(async () => {
+      const fresh = await getDubbing(projectId, session.access_token).catch(() => null)
+      if (fresh) setDubbing(fresh)
+    }, 4000)
+    return () => clearInterval(iv)
+  }, [status, projectId, session?.access_token])
+
   const handleDelete = async () => {
     if (!projectId) return
-
     setIsDeleting(true)
     try {
       const success = await deleteDubbing(projectId, session?.access_token)
       if (success) {
-        toast.success("Dubbing deleted!", {
-          description: "The dubbed media has been successfully deleted.",
-        })
+        toast.success("Dubbing deleted!", { description: "The dubbed media has been successfully deleted." })
         router.push("/dashboard/dubbing")
       } else {
         throw new Error("Failed to delete")
       }
     } catch (error: any) {
-      toast.error("Error deleting dubbing", {
-        description: error.message || "Failed to delete dubbing.",
-      })
+      toast.error("Error deleting dubbing", { description: error.message || "Failed to delete dubbing." })
     } finally {
       setIsDeleting(false)
+    }
+  }
+
+  const handleRegenerate = async () => {
+    setIsRegenerating(true)
+    try {
+      await regenerateDubbing(projectId, session?.access_token)
+      toast.success("Regeneration started", { description: "Re-dubbing your media with the same settings." })
+      const fresh = await getDubbing(projectId, session?.access_token).catch(() => null)
+      if (fresh) setDubbing(fresh)
+    } catch (error: any) {
+      toast.error("Could not regenerate", { description: error?.message || "Please try again." })
+    } finally {
+      setIsRegenerating(false)
     }
   }
 
@@ -91,10 +139,9 @@ export default function DubbingDetailPage() {
     if (!dubbing?.dubbedUrl) return
     setIsDownloading(true)
     try {
-      const ext = dubbing.isVideo ? "mp4" : "mp3"
+      const ext = dubbing.isVideo ? "mp4" : "wav"
       const baseName = dubbing.mediaName || `dubbed_${dubbing.isVideo ? "video" : "audio"}_${dubbing.targetLanguage}`
-      const filename = `${baseName}.${ext}`
-      await downloadFile(dubbing.dubbedUrl, filename)
+      await downloadFile(dubbing.dubbedUrl, `${baseName}.${ext}`)
       toast.success("Download started")
     } catch {
       toast.error("Download failed", { description: "Please try again" })
@@ -110,211 +157,159 @@ export default function DubbingDetailPage() {
       </div>
     )
   }
-
-  if (!dubbing) {
-    return null
-  }
+  if (!dubbing) return null
 
   const languageLabel = getLanguageLabel(dubbing.targetLanguage)
-  const isCompleted = dubbing.status === "dubbed" && dubbing.dubbedUrl
+  // Lifecycle: queued → processing → cloning → completed | failed
+  const isCompleted = dubbing.status === "completed" && !!dubbing.dubbedUrl
+  const isFailed = dubbing.status === "failed"
+  const isProcessing = !isCompleted && !isFailed
+
+  const StatusIcon = isCompleted ? CheckCircle2 : isFailed ? XCircle : Loader2
+  const statusColor = isCompleted
+    ? "text-green-600 dark:text-green-400"
+    : isFailed
+      ? "text-red-500"
+      : "text-purple-600 dark:text-purple-400"
+
+  const createdLabel = new Date(dubbing.createdAt).toLocaleDateString(undefined, {
+    year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+  })
 
   return (
     <div className="container py-8">
-      <div className="mb-8 flex flex-col items-start gap-4 sm:flex-row sm:justify-between sm:items-center">
+      {/* Header — icon-only back button on the left */}
+      <div className="mb-8 flex items-center gap-4">
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="outline" size="icon" onClick={() => router.push("/dashboard/dubbing")} className="shrink-0" aria-label="Back to Dubbings">
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Back to Dubbings</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Dubbing Details</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
-            Preview and download your dubbed media
-          </p>
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Details</h1>
         </div>
-        <Button
-          variant="outline"
-          onClick={() => router.push("/dashboard/dubbing")}
-          className="flex items-center gap-2"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back to Dubbings
-        </Button>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Main Preview Card */}
-        <div className="lg:col-span-2">
+      <motion.div className="space-y-8" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.4 }}>
+        {/* 1. Details — glassy quick-action-style cards, full width */}
+        <section aria-label="Details">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50 mb-4">Details</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+            <StatCard icon={dubbing.isVideo ? Video : Music} label="Media Type" value={dubbing.isVideo ? "Video" : "Audio"} />
+            <StatCard icon={Languages} label="Target Language" value={languageLabel} />
+            <StatCard icon={StatusIcon} label="Status" value={dubbing.status} iconClassName={`${statusColor} ${isProcessing ? "[&>svg]:animate-spin" : ""}`} />
+            <StatCard icon={Coins} label="Credits Used" value={dubbing.creditsConsumed ? `${dubbing.creditsConsumed}` : "—"} />
+            <StatCard icon={CalendarDays} label="Created" value={createdLabel} />
+          </div>
+        </section>
+
+        {/* 2. Main media section — full width */}
+        <section aria-label="Preview">
           <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                {isCompleted ? (
-                  <CheckCircle2 className="h-5 w-5 text-green-500" />
-                ) : (
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                )}
-                {dubbing.mediaName || (isCompleted ? "Dubbing Complete" : "Processing...")}
-              </CardTitle>
-              <CardDescription>
-                {isCompleted
-                  ? `Your media has been dubbed into ${languageLabel}. Preview and download below.`
-                  : "Your dubbing is still being processed. Please check back later."}
-              </CardDescription>
+            <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+              <div className="min-w-0">
+                <CardTitle className="flex items-center gap-2">
+                  <StatusIcon className={`h-5 w-5 shrink-0 ${statusColor} ${isProcessing ? "animate-spin" : ""}`} />
+                  <span className="truncate">
+                    {dubbing.mediaName || (isCompleted ? "Dubbing Complete" : isFailed ? "Dubbing Failed" : "Processing…")}
+                  </span>
+                </CardTitle>
+                <CardDescription className="mt-1.5">
+                  {isCompleted
+                    ? `Dubbed into ${languageLabel}. Preview and download below.`
+                    : isFailed
+                      ? "This dubbing did not complete. No credits were charged."
+                      : "Your dubbing is being processed — this page updates automatically."}
+                </CardDescription>
+              </div>
+
+              {/* Icon toolbar — before the preview */}
+              <TooltipProvider delayDuration={0}>
+                <div className="flex items-center gap-2 shrink-0">
+                  {isCompleted && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button size="icon" onClick={handleDownload} disabled={isDownloading} className="bg-purple-600 hover:bg-purple-700 text-white" aria-label={`Download ${dubbing.isVideo ? "video" : "audio"}`}>
+                          {isDownloading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Download {dubbing.isVideo ? "video" : "audio"}</TooltipContent>
+                    </Tooltip>
+                  )}
+
+                  {!isProcessing && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button variant="outline" size="icon" onClick={handleRegenerate} disabled={isRegenerating} aria-label="Regenerate">
+                          {isRegenerating ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCw className="h-4 w-4" />}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Regenerate with same input</TooltipContent>
+                    </Tooltip>
+                  )}
+
+                  <AlertDialog>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <AlertDialogTrigger asChild>
+                          <Button variant="outline" size="icon" disabled={isDeleting} className="text-red-500 hover:text-red-600 hover:bg-red-500/10 border-red-500/30 hover:border-red-500/50" aria-label="Delete dubbing">
+                            {isDeleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                          </Button>
+                        </AlertDialogTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent>Delete dubbing</TooltipContent>
+                    </Tooltip>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This action cannot be undone. This will permanently delete this dubbed media.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              </TooltipProvider>
             </CardHeader>
+
             <CardContent className="space-y-6">
               {isCompleted && dubbing.dubbedUrl ? (
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   {dubbing.originalMediaUrl && (
-                    <div className="space-y-4">
+                    <div className="space-y-3">
                       <Label>Original Media</Label>
-                      <div className="rounded-lg border bg-slate-50 dark:bg-slate-900/40 p-4">
-                        {dubbing.isVideo ? (
-                          <video
-                            controls
-                            src={dubbing.originalMediaUrl}
-                            className="w-full max-h-[300px] rounded-lg"
-                          >
-                            Your browser does not support the video element.
-                          </video>
-                        ) : (
-                          <audio controls src={dubbing.originalMediaUrl} className="w-full">
-                            Your browser does not support the audio element.
-                          </audio>
-                        )}
-                      </div>
+                      <DubbingMediaPlayer url={dubbing.originalMediaUrl} isVideo={dubbing.isVideo} title="Original media" />
                     </div>
                   )}
-                  <div className="space-y-4">
+                  <div className="space-y-3">
                     <Label>Dubbed Media ({languageLabel})</Label>
-                    <div className="rounded-lg border bg-slate-50 dark:bg-slate-900/40 p-4">
-                      {dubbing.isVideo ? (
-                        <video
-                          controls
-                          src={dubbing.dubbedUrl}
-                          className="w-full max-h-[300px] rounded-lg"
-                        >
-                          Your browser does not support the video element.
-                        </video>
-                      ) : (
-                        <audio controls src={dubbing.dubbedUrl} className="w-full">
-                          Your browser does not support the audio element.
-                        </audio>
-                      )}
-                    </div>
+                    <DubbingMediaPlayer url={dubbing.dubbedUrl} isVideo={dubbing.isVideo} title={dubbing.mediaName || "Dubbed media"} />
                   </div>
                 </div>
+              ) : isFailed ? (
+                <div className="text-center py-16 text-slate-500">
+                  <XCircle className="h-12 w-12 mx-auto mb-4 text-red-400" />
+                  <p>Dubbing failed or was cancelled. Regenerate to try again, or delete this project.</p>
+                </div>
               ) : (
-                <div className="text-center py-12 text-slate-500">
-                  <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4" />
-                  <p>Your dubbing is still being processed...</p>
+                <div className="text-center py-16 text-slate-500">
+                  <Loader2 className="h-12 w-12 animate-spin mx-auto mb-4 text-purple-500" />
+                  <p>Your dubbing is still being processed…</p>
                 </div>
               )}
             </CardContent>
-            <CardFooter className="flex flex-col-reverse sm:flex-row sm:justify-between sm:items-center gap-4">
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="w-full sm:w-auto text-red-500 hover:text-red-600 hover:bg-red-500/10 border-red-500/30 hover:border-red-500/50"
-                    disabled={isDeleting}
-                  >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    Delete Dubbing
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Are you sure?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This action cannot be undone. This will permanently delete this dubbed media.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">
-                      Delete
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-
-              {isCompleted && (
-                <Button
-                  onClick={handleDownload}
-                  className="w-full sm:w-auto bg-slate-950 hover:bg-slate-900 text-white"
-                  disabled={isDownloading}
-                >
-                  {isDownloading ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <Download className="mr-2 h-4 w-4" />
-                  )}
-                  {isDownloading ? "Downloading..." : `Download ${dubbing.isVideo ? "Video" : "Audio"}`}
-                </Button>
-              )}
-            </CardFooter>
           </Card>
-        </div>
-
-        {/* Metadata Card */}
-        <div className="lg:col-span-1">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Details</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-center gap-3">
-                <div className="flex-shrink-0 bg-purple-50 dark:bg-purple-900/20 p-2 rounded-lg">
-                  {dubbing.isVideo ? (
-                    <Video className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                  ) : (
-                    <Music className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                  )}
-                </div>
-                <div>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">Media Type</p>
-                  <p className="font-medium">{dubbing.isVideo ? "Video" : "Audio"}</p>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-3">
-                <div className="flex-shrink-0 bg-purple-50 dark:bg-purple-900/20 p-2 rounded-lg">
-                  <Languages className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                </div>
-                <div>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">Target Language</p>
-                  <p className="font-medium">{languageLabel}</p>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-3">
-                <div className="flex-shrink-0 bg-purple-50 dark:bg-purple-900/20 p-2 rounded-lg">
-                  <CheckCircle2 className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                </div>
-                <div>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">Status</p>
-                  <p className="font-medium capitalize">{dubbing.status}</p>
-                </div>
-              </div>
-
-              {dubbing.creditsConsumed !== undefined && dubbing.creditsConsumed > 0 && (
-                <div className="pt-4 border-t">
-                  <p className="text-sm text-slate-500 dark:text-slate-400">Credits Used</p>
-                  <p className="font-medium">{dubbing.creditsConsumed} credits</p>
-                </div>
-              )}
-
-              <div className="pt-4 border-t">
-                <p className="text-sm text-slate-500 dark:text-slate-400">Created</p>
-                <p className="font-medium">
-                  {new Date(dubbing.createdAt).toLocaleDateString(undefined, {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+        </section>
+      </motion.div>
     </div>
   )
 }

--- a/apps/web/app/dashboard/dubbing/new/page.tsx
+++ b/apps/web/app/dashboard/dubbing/new/page.tsx
@@ -1,20 +1,95 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
+import { motion, AnimatePresence } from "motion/react";
 import { toast } from "sonner";
 import { Button } from "@repo/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@repo/ui/card";
 import { Input } from "@repo/ui/input";
 import { Label } from "@repo/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui/select";
-import { Progress } from "@repo/ui/progress";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@repo/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@repo/ui/tooltip";
-import { Loader2, Play, Download, UploadCloud, RefreshCw, ArrowLeft, CheckCircle2, Clock } from "lucide-react";
+import {
+  Loader2, Play, Download, UploadCloud, ArrowLeft, CheckCircle2,
+  Mic, Languages, FileAudio, FileVideo, Sparkles, ArrowUpRight, Type,
+  Clapperboard, Music, RotateCw, Plus, List,
+} from "lucide-react";
 import { useDubbing } from "@/hooks/useDubbing";
 import { supportedLanguages } from "@repo/validation";
 import { downloadFile } from "@/lib/download";
+import { GenerationProgress, type GenerationProgressStep } from "@/components/dashboard/common/GenerationProgress";
+import { DubbingHowItWorks } from "@/components/dashboard/dubbing/DubbingHowItWorks";
+import { DubbingVoiceAnimation } from "@/components/dashboard/dubbing/DubbingVoiceAnimation";
+import { DubbingMediaPlayer } from "@/components/dashboard/dubbing/DubbingMediaPlayer";
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { staggerChildren: 0.08 } },
+};
+const itemVariants = {
+  hidden: { opacity: 0, y: 16 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: "easeOut" as const } },
+};
+
+/** Paid-only gate — dark card mirroring VideoUpgradeCard's visual language. */
+function DubbingUpgradeCard() {
+  const router = useRouter();
+  return (
+    <motion.div variants={itemVariants}>
+      <div className="group relative bg-slate-900 rounded-3xl p-8 sm:p-10 text-white overflow-hidden shadow-xl shadow-slate-200 dark:shadow-none">
+        <div className="absolute -top-12 -right-12 w-40 h-40 bg-violet-600/30 rounded-full blur-3xl group-hover:bg-violet-500/40 transition-colors duration-500" />
+        <div className="absolute -bottom-12 -left-12 w-40 h-40 bg-blue-600/20 rounded-full blur-3xl" />
+        <div className="relative z-10 max-w-lg">
+          <div className="inline-flex p-3 rounded-2xl bg-white/10 backdrop-blur-md mb-6">
+            <Mic className="h-6 w-6 text-violet-300" />
+          </div>
+          <h3 className="text-2xl font-bold mb-3">Audio dubbing is a paid feature</h3>
+          <p className="text-slate-400 text-sm leading-relaxed mb-8">
+            Clone a voice and dub audio or video into 21 languages while keeping the original
+            voice. It&apos;s included in Creator, Pro, Business and Scale — upgrade from Starter
+            to start dubbing your media.
+          </p>
+          <button
+            onClick={() => router.push("/pricing")}
+            className="w-full sm:w-auto flex items-center justify-center gap-2 bg-white text-slate-900 font-bold px-8 py-4 rounded-2xl hover:bg-slate-50 transition-all transform active:scale-[0.98]"
+          >
+            View Plans <ArrowUpRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+/** Icon-only button with a tooltip — used for the result-card toolbar. */
+function IconAction({
+  label, onClick, disabled, primary, children,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  primary?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant={primary ? "default" : "outline"}
+          size="icon"
+          onClick={onClick}
+          disabled={disabled}
+          className={primary ? "bg-purple-600 hover:bg-purple-700 text-white" : ""}
+          aria-label={label}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export default function NewDubbing() {
   const router = useRouter();
@@ -29,38 +104,37 @@ export default function NewDubbing() {
     dubbedResult,
     progress,
     isLoading,
+    allowed,
+    accessLoading,
+    canCancel,
+    cancelDub,
     handleFileChange,
+    handleFileSelect,
     resetForm,
     handleDubMedia,
   } = useDubbing();
 
-  const [activeTab, setActiveTab] = useState("create");
-
-  const isComingSoon = true;
-
-  // Auto-switch to preview tab when dubbing completes
-  useEffect(() => {
-    if (dubbedResult && progress.state === "completed") {
-      setActiveTab("preview");
-    }
-  }, [dubbedResult, progress.state]);
-
-  const handleCreateNew = () => {
-    resetForm();
-    setActiveTab("create");
-  };
-
-  const selectedLanguageLabel = supportedLanguages.find(
-    (l) => l.value === targetLanguage
-  )?.label;
-
+  const [isDragging, setIsDragging] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
+
+  const selectedLanguageLabel = supportedLanguages.find((l) => l.value === targetLanguage)?.label;
+  const isComplete = !!dubbedResult && progress.state === "completed";
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      if (isLoading) return;
+      handleFileSelect(e.dataTransfer.files?.[0]);
+    },
+    [handleFileSelect, isLoading],
+  );
 
   const handleDownload = useCallback(async () => {
     if (!dubbedResult?.dubbedUrl) return;
     setIsDownloading(true);
     try {
-      const ext = isVideo ? "mp4" : "mp3";
+      const ext = isVideo ? "mp4" : "wav";
       const filename = `dubbed_${isVideo ? "video" : "audio"}_${dubbedResult.targetLanguage}.${ext}`;
       await downloadFile(dubbedResult.dubbedUrl, filename);
     } catch {
@@ -70,230 +144,266 @@ export default function NewDubbing() {
     }
   }, [dubbedResult, isVideo]);
 
+  // Stepped states for the animated progress bar (AI Studio pattern).
+  const DUB_STEPS: GenerationProgressStep[] = [
+    { label: "Queued", icon: Loader2, threshold: 0 },
+    { label: "Translating", icon: Languages, threshold: 16 },
+    { label: "Cloning", icon: Mic, threshold: 40 },
+    { label: isVideo ? "Rendering" : "Finalizing", icon: isVideo ? Clapperboard : Music, threshold: 82 },
+    { label: "Done", icon: CheckCircle2, threshold: 100 },
+  ];
+
   return (
-    <div className="container py-8 max-w-full mx-auto relative">
-      <div className="mb-8 flex flex-col items-start gap-4 sm:flex-row sm:justify-between sm:items-center">
+    <motion.div
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+      className="container py-8 relative"
+    >
+      <div className="absolute top-0 right-1/4 w-[400px] h-[400px] bg-purple-400/10 rounded-full blur-[100px] -z-10 pointer-events-none" />
+
+      {/* Header — icon-only back button on the left */}
+      <motion.div variants={itemVariants} className="mb-8 flex items-center gap-4">
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => router.push("/dashboard/dubbing")}
+                className="shrink-0"
+                aria-label="Back to Dubbings"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Back to Dubbings</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">New Dubbing</h1>
-          <p className="text-slate-600 dark:text-slate-400 mt-1">
-            Upload an audio or video file and dub it into another language with AI.
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight flex items-center gap-2">
+            <Mic className="h-6 w-6 sm:h-7 sm:w-7 text-purple-500" />
+            New Dubbing
+          </h1>
+          <p className="text-slate-600 dark:text-slate-400 mt-1 text-sm sm:text-base">
+            Upload an audio or video file and dub it into another language in the original voice.
           </p>
         </div>
-        <Button
-          variant="outline"
-          onClick={() => router.push("/dashboard/dubbing")}
-          className="flex items-center gap-2"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back to Dubbings
-        </Button>
-      </div>
+      </motion.div>
 
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-        <TabsList className="sticky top-1 z-20 grid w-full grid-cols-2 bg-background shadow-sm">
-          <TabsTrigger value="create">Create Dub</TabsTrigger>
-          <TabsTrigger value="preview" disabled={!dubbedResult}>
-            Preview Result
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="create" className="mt-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Dub Your Media</CardTitle>
-              <CardDescription>
-                Translate your audio or video into one of 29 languages while keeping the original voice characteristics.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-2">
-                <Label htmlFor="media-name">Media Name</Label>
-                <Input
-                  id="media-name"
-                  type="text"
-                  placeholder="Enter a name for your dubbed media"
-                  value={mediaName}
-                  onChange={(e) => setMediaName(e.target.value)}
-                  disabled={isLoading}
-                  maxLength={100}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex justify-between items-center">
-                  <Label htmlFor="media-upload">Upload Audio or Video File</Label>
-                  {progress.state === "failed" && (
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button variant="ghost" size="icon" onClick={resetForm}>
-                            <RefreshCw className="h-4 w-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Try Again</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  )}
-                </div>
-                <Input
-                  ref={fileInputRef}
-                  id="media-upload"
-                  type="file"
-                  accept="audio/*,video/*"
-                  onChange={handleFileChange}
-                  disabled={isLoading}
-                />
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  Upload MP3, WAV, MP4, or MOV (max 500MB, 45 minutes).
+      {accessLoading ? (
+        <motion.div variants={itemVariants} className="flex justify-center py-24">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+        </motion.div>
+      ) : !allowed ? (
+        <DubbingUpgradeCard />
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
+          {/* LEFT — animated hero + how it works (stacks on top on mobile) */}
+          <motion.div variants={itemVariants} className="lg:col-span-5 xl:col-span-4 lg:sticky lg:top-8 space-y-6">
+            <Card className="overflow-hidden border-purple-100 dark:border-purple-900/40 bg-gradient-to-br from-purple-50 to-white dark:from-purple-950/30 dark:to-slate-900">
+              <CardContent className="pt-6 pb-4 text-center">
+                <DubbingVoiceAnimation />
+                <h2 className="text-lg font-bold text-slate-900 dark:text-slate-50 mt-2">
+                  One voice, every language
+                </h2>
+                <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+                  Clone the speaker and re-voice their content, no re-recording.
                 </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="target-language">Target Language</Label>
-                <Select
-                  value={targetLanguage}
-                  onValueChange={setTargetLanguage}
-                  disabled={isLoading}
-                >
-                  <SelectTrigger id="target-language">
-                    <SelectValue placeholder="Select a language" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {supportedLanguages.map((lang) => (
-                      <SelectItem key={lang.value} value={lang.value}>
-                        {lang.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {progress.state !== "idle" && (
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      {progress.state === "uploading" && <UploadCloud className="h-4 w-4" />}
-                      {progress.state === "processing" && <Loader2 className="h-4 w-4 animate-spin" />}
-                      {progress.state === "completed" && <CheckCircle2 className="h-4 w-4 text-green-500" />}
-                      <span className="text-sm font-medium">{progress.message}</span>
-                    </div>
-                    <span className="text-sm text-slate-500">{Math.round(progress.progress)}%</span>
-                  </div>
-                  <Progress value={progress.progress} className="w-full h-2" />
-                </div>
-              )}
-            </CardContent>
-            <CardFooter className="flex justify-between">
-              <div />
-              <Button
-                onClick={handleDubMedia}
-                className="bg-slate-950 hover:bg-slate-900 text-white"
-                disabled={isLoading || !mediaFile || !targetLanguage || !mediaName.trim() || progress.state === "completed"}
-              >
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Processing...
-                  </>
-                ) : (
-                  <>
-                    <Play className="mr-2 h-4 w-4" />
-                    Dub
-                  </>
-                )}
-              </Button>
-            </CardFooter>
-          </Card>
-        </TabsContent>
-
-        <TabsContent value="preview" className="mt-6">
-          {dubbedResult && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <CheckCircle2 className="h-5 w-5 text-green-500" />
-                  Dubbing Complete
-                </CardTitle>
-                <CardDescription>
-                  Your media has been dubbed into {selectedLanguageLabel}. Preview and download below.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="space-y-4">
-                  <Label>Preview</Label>
-                  <div className="rounded-lg border bg-slate-50 dark:bg-slate-900/40 p-4">
-                    {isVideo ? (
-                      <video
-                        controls
-                        src={dubbedResult.dubbedUrl}
-                        className="w-full max-h-[400px] rounded-lg"
-                      >
-                        Your browser does not support the video element.
-                      </video>
-                    ) : (
-                      <audio
-                        controls
-                        src={dubbedResult.dubbedUrl}
-                        className="w-full"
-                      >
-                        Your browser does not support the audio element.
-                      </audio>
-                    )}
-                  </div>
-                </div>
               </CardContent>
-              <CardFooter className="flex flex-col sm:flex-row justify-between gap-3 pt-6 border-t">
-                <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
-                  <Button variant="outline" onClick={() => router.push("/dashboard/dubbing")} className="w-full sm:w-auto">
-                    <ArrowLeft className="mr-2 h-4 w-4" />
-                    Back to List
-                  </Button>
-                  <Button variant="outline" onClick={handleCreateNew} className="w-full sm:w-auto">
-                    <RefreshCw className="mr-2 h-4 w-4" />
-                    Dub Another
-                  </Button>
-                </div>
-                <Button
-                  className="w-full sm:w-auto bg-slate-950 hover:bg-slate-900 text-white"
-                  onClick={handleDownload}
-                  disabled={isDownloading}
-                >
-                  {isDownloading ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <Download className="mr-2 h-4 w-4" />
-                  )}
-                  {isDownloading ? "Downloading..." : `Download ${isVideo ? "Video" : "Audio"}`}
-                </Button>
-              </CardFooter>
             </Card>
-          )}
-        </TabsContent>
-      </Tabs>
 
-      {isComingSoon && (
-        <div className="absolute inset-0 bg-slate-100/80 dark:bg-slate-900/80 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="text-center space-y-4 px-4 max-w-md">
-            <Clock className="h-12 w-12 mx-auto text-slate-500 dark:text-slate-400" />
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
-              Coming Soon
-            </h2>
-            <p className="text-slate-600 dark:text-slate-400">
-              AI-powered audio &amp; video dubbing is under preparation.<br />
-              Stay tuned, launching very soon!
-            </p>
-            <Button
-              variant="outline"
-              onClick={() => router.push("/dashboard")}
-              className="bg-slate-950 hover:bg-slate-900 text-white"
-            >
-              Back to Dashboard
-            </Button>
-          </div>
+            <Card>
+              <CardContent className="py-2">
+                <DubbingHowItWorks />
+              </CardContent>
+            </Card>
+          </motion.div>
+
+          {/* RIGHT — form / progress / result */}
+          <motion.div variants={itemVariants} className="lg:col-span-7 xl:col-span-8">
+            <AnimatePresence mode="wait">
+              {isLoading ? (
+                <motion.div key="progress" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                  <GenerationProgress
+                    progress={Math.round(progress.progress)}
+                    statusMessage={progress.message || "Starting…"}
+                    title="Dubbing in Progress"
+                    icon={Mic}
+                    steps={DUB_STEPS}
+                    hint={isVideo ? "Rendering video can take a few minutes" : "This usually takes under a minute"}
+                    onStop={canCancel ? cancelDub : undefined}
+                    stopLabel="Cancel Dubbing"
+                  />
+                </motion.div>
+              ) : isComplete ? (
+                <motion.div key="result" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }}>
+                  <Card>
+                    <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+                      <div className="min-w-0">
+                        <CardTitle className="flex items-center gap-2">
+                          <CheckCircle2 className="h-5 w-5 text-green-500 shrink-0" />
+                          Dubbing Complete
+                        </CardTitle>
+                        <CardDescription className="mt-1.5">
+                          Dubbed into {selectedLanguageLabel}. Preview, regenerate or download below.
+                        </CardDescription>
+                      </div>
+
+                      {/* Icon toolbar — before the preview */}
+                      <TooltipProvider delayDuration={0}>
+                        <div className="flex items-center gap-2 shrink-0">
+                          <IconAction label="Back to list" onClick={() => router.push("/dashboard/dubbing")}>
+                            <List className="h-4 w-4" />
+                          </IconAction>
+                          <IconAction label="Dub another file" onClick={resetForm}>
+                            <Plus className="h-4 w-4" />
+                          </IconAction>
+                          <IconAction label="Regenerate" onClick={handleDubMedia}>
+                            <RotateCw className="h-4 w-4" />
+                          </IconAction>
+                          <IconAction label={`Download ${isVideo ? "video" : "audio"}`} onClick={handleDownload} disabled={isDownloading} primary>
+                            {isDownloading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                          </IconAction>
+                        </div>
+                      </TooltipProvider>
+                    </CardHeader>
+                    <CardContent>
+                      <DubbingMediaPlayer
+                        url={dubbedResult!.dubbedUrl!}
+                        isVideo={isVideo}
+                        title={mediaName || `Dubbed ${isVideo ? "video" : "audio"}`}
+                      />
+                    </CardContent>
+                  </Card>
+                </motion.div>
+              ) : (
+                <motion.div key="form" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                  <Card className="transition-all duration-300 hover:shadow-[0_8px_30px_rgba(168,85,247,0.10)] hover:border-purple-500/40">
+                    <CardHeader>
+                      <CardTitle className="flex items-center gap-2">
+                        <Sparkles className="h-5 w-5 text-purple-500" />
+                        Dub Your Media
+                      </CardTitle>
+                      <CardDescription>
+                        Translate your audio or video into one of 21 languages while keeping the original voice characteristics.
+                      </CardDescription>
+                    </CardHeader>
+
+                    <CardContent className="space-y-6">
+                      {/* Media Name */}
+                      <div className="space-y-2">
+                        <Label htmlFor="media-name" className="flex items-center gap-1.5">
+                          <Type className="h-4 w-4" />
+                          Media Name
+                        </Label>
+                        <Input
+                          id="media-name"
+                          placeholder="Enter a name for your dubbed media"
+                          value={mediaName}
+                          onChange={(e) => setMediaName(e.target.value)}
+                          maxLength={100}
+                        />
+                      </div>
+
+                      {/* Animated upload drop zone */}
+                      <div className="space-y-2">
+                        <Label className="flex items-center gap-1.5">
+                          <UploadCloud className="h-4 w-4" />
+                          Upload Audio or Video File
+                        </Label>
+
+                        <Label
+                          htmlFor="media-upload"
+                          onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+                          onDragLeave={() => setIsDragging(false)}
+                          onDrop={handleDrop}
+                          className={`group relative flex w-full cursor-pointer flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed py-12 px-6 transition-all duration-300 ${isDragging
+                            ? "border-purple-400 bg-purple-50 dark:bg-purple-900/20 scale-[1.01]"
+                            : mediaFile
+                              ? "border-purple-300 bg-purple-50/40 dark:bg-purple-900/10"
+                              : "border-slate-200 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/20 hover:bg-purple-50/60 dark:hover:bg-purple-900/10 hover:border-purple-300"
+                            }`}
+                        >
+                          <motion.div
+                            whileHover={{ scale: 1.08 }}
+                            whileTap={{ scale: 0.94 }}
+                            className={`h-16 w-16 rounded-full flex items-center justify-center shadow-lg transition-colors duration-300 ${mediaFile ? "bg-purple-600" : "bg-slate-900 dark:bg-slate-700 group-hover:bg-purple-600"
+                              }`}
+                          >
+                            {mediaFile ? (
+                              isVideo ? <FileVideo className="h-7 w-7 text-white" /> : <FileAudio className="h-7 w-7 text-white" />
+                            ) : (
+                              <UploadCloud className="h-7 w-7 text-white" />
+                            )}
+                          </motion.div>
+
+                          <div className="text-center">
+                            <p className="text-base font-semibold text-slate-900 dark:text-slate-100 break-all">
+                              {mediaFile ? mediaFile.name : isDragging ? "Drop your file here" : "Drag & drop your file"}
+                            </p>
+                            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                              {mediaFile ? (
+                                `${(mediaFile.size / (1024 * 1024)).toFixed(2)} MB · click to change`
+                              ) : (
+                                <>or <span className="text-purple-600 dark:text-purple-400 font-medium underline underline-offset-2">browse files</span></>
+                              )}
+                            </p>
+                          </div>
+
+                          <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[11px] text-slate-400 uppercase tracking-widest font-bold">
+                            <span>MP3 · WAV · MP4 · MOV</span>
+                            <span className="hidden sm:inline w-1 h-1 bg-slate-300 dark:bg-slate-600 rounded-full" />
+                            <span>Max 500MB · 45 min</span>
+                          </div>
+                        </Label>
+                        <Input
+                          ref={fileInputRef}
+                          id="media-upload"
+                          type="file"
+                          accept="audio/*,video/*"
+                          className="hidden"
+                          onChange={handleFileChange}
+                        />
+                      </div>
+
+                      {/* Target Language */}
+                      <div className="space-y-2">
+                        <Label htmlFor="target-language" className="flex items-center gap-1.5">
+                          <Languages className="h-4 w-4" />
+                          Target Language
+                        </Label>
+                        <Select value={targetLanguage} onValueChange={setTargetLanguage}>
+                          <SelectTrigger id="target-language">
+                            <SelectValue placeholder="Select a language" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {supportedLanguages.map((lang) => (
+                              <SelectItem key={lang.value} value={lang.value}>{lang.label}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </CardContent>
+
+                    <CardFooter>
+                      <Button
+                        onClick={handleDubMedia}
+                        size="lg"
+                        className="w-full bg-purple-600 hover:bg-purple-700 text-white transition-all active:scale-[0.98]"
+                        disabled={!mediaFile || !targetLanguage || !mediaName.trim()}
+                      >
+                        <Play className="mr-2 h-4 w-4" />
+                        Dub {selectedLanguageLabel ? `to ${selectedLanguageLabel}` : "Media"}
+                      </Button>
+                    </CardFooter>
+                  </Card>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.div>
         </div>
       )}
-    </div>
+    </motion.div>
   );
 }

--- a/apps/web/app/dashboard/dubbing/page.tsx
+++ b/apps/web/app/dashboard/dubbing/page.tsx
@@ -2,12 +2,11 @@
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"           // ← added
 import { Button } from "@repo/ui/button"
 import { Input } from "@repo/ui/input"
 import { toast } from "sonner"
 import { useSupabase } from "@/components/supabase-provider"
-import { Plus, Search, Clock } from "lucide-react"    // ← added Clock
+import { Plus, Search } from "lucide-react"
 import { AnimatePresence, motion } from "motion/react"
 import { ContentCard } from "@/components/dashboard/common/ContentCard"
 import ContentCardSkeleton from "@/components/dashboard/common/skeleton/ContentCardSkeleton"
@@ -45,13 +44,10 @@ function formatTitle(project: DubbingProject): string {
 
 export default function DubbingList() {
   const { session } = useSupabase()
-  const router = useRouter()                                 // ← added
   const [dubbings, setDubbings] = useState<DubbingProject[]>([])
   const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState("")
   const [dubbingToDelete, setDubbingToDelete] = useState<string | null>(null)
-
-  const isComingSoon = true
 
   useEffect(() => {
     const fetchDubbings = async () => {
@@ -101,7 +97,7 @@ export default function DubbingList() {
   })
 
   return (
-    <div className="container py-8 relative">           {/* ← added relative */}
+    <div className="container py-8">
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -117,7 +113,6 @@ export default function DubbingList() {
           </div>
           <Button
             className="bg-slate-900 hover:bg-slate-800 text-white transition-all hover:shadow-lg hover:shadow-purple-500/10 dark:hover:shadow-purple-400/10"
-            disabled={isComingSoon}
             asChild
           >
             <Link href="/dashboard/dubbing/new">
@@ -136,7 +131,6 @@ export default function DubbingList() {
               className="pl-10 focus-visible:ring-2 focus-visible:ring-purple-500/80"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              disabled={isComingSoon}
             />
           </div>
         </div>
@@ -159,7 +153,6 @@ export default function DubbingList() {
                   onDelete={handleDeleteDubbing}
                   setToDelete={setDubbingToDelete}
                   type="dubbing"
-                // You can also pass disabled={isComingSoon} to ContentCard if it has interactive parts
                 />
               ))}
             </motion.div>
@@ -184,7 +177,6 @@ export default function DubbingList() {
                   {!searchQuery && (
                     <Button
                       className="bg-slate-900 hover:bg-slate-800 text-white transition-all"
-                      disabled={isComingSoon}
                       asChild
                     >
                       <Link href="/dashboard/dubbing/new">
@@ -199,29 +191,6 @@ export default function DubbingList() {
           )}
         </AnimatePresence>
       </motion.div>
-
-      {/* Coming Soon Overlay, identical style to Thumbnail page */}
-      {isComingSoon && (
-        <div className="absolute inset-0 bg-slate-100/80 dark:bg-slate-900/80 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="text-center space-y-4 px-4 max-w-md">
-            <Clock className="h-12 w-12 mx-auto text-slate-500 dark:text-slate-400" />
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
-              Coming Soon
-            </h2>
-            <p className="text-slate-600 dark:text-slate-400">
-              AI-powered audio & video dubbing is under preparation.<br />
-              Stay tuned, launching very soon!
-            </p>
-            <Button
-              variant="outline"
-              onClick={() => router.push("/dashboard")}
-              className="bg-slate-950 hover:bg-slate-900 text-white"
-            >
-              Back to Topics
-            </Button>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/web/components/dashboard/common/GenerationProgress.tsx
+++ b/apps/web/components/dashboard/common/GenerationProgress.tsx
@@ -21,6 +21,7 @@ interface GenerationProgressProps {
   hint?: string
   compact?: boolean
   onStop?: () => void
+  stopLabel?: string
 }
 
 const DEFAULT_STEPS: GenerationProgressStep[] = [
@@ -40,6 +41,7 @@ export function GenerationProgress({
   hint,
   compact = false,
   onStop,
+  stopLabel = "Stop Training",
 }: GenerationProgressProps) {
   const resolvedSteps = steps.length > 0 ? steps : DEFAULT_STEPS
 
@@ -132,7 +134,7 @@ export function GenerationProgress({
           className="text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700 dark:border-red-800 dark:hover:bg-red-950/30"
         >
           <Square className="mr-1.5 h-3.5 w-3.5 fill-current" />
-          Stop Training
+          {stopLabel}
         </Button>
       )}
     </>

--- a/apps/web/components/dashboard/dubbing/DubbingHowItWorks.tsx
+++ b/apps/web/components/dashboard/dubbing/DubbingHowItWorks.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { motion } from "motion/react";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@repo/ui/accordion";
+import { UploadCloud, Languages, Mic, Clapperboard } from "lucide-react";
+
+const steps = [
+  { step: 1, title: "Upload media", desc: "Drop in an audio or video file up to 500MB, 45 minutes.", icon: UploadCloud },
+  { step: 2, title: "Transcribe & translate", desc: "We transcribe the speech and translate it into your target language.", icon: Languages },
+  { step: 3, title: "Clone the voice", desc: "The original voice is cloned and speaks the translation naturally.", icon: Mic },
+  { step: 4, title: "Merge & preview", desc: "For video, the dubbed audio is merged back over your footage.", icon: Clapperboard },
+];
+
+export function DubbingHowItWorks() {
+  return (
+    <Accordion type="single" collapsible defaultValue="how-it-works" className="w-full">
+      <AccordionItem value="how-it-works" className="border-none">
+        <AccordionTrigger className="font-semibold">How does audio dubbing work?</AccordionTrigger>
+        <AccordionContent className="pt-4">
+          <div className="space-y-6">
+            {steps.map(({ step, title, desc, icon: Icon }) => (
+              <motion.div
+                key={step}
+                initial={{ opacity: 0, x: -12 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: step * 0.08, duration: 0.35 }}
+                className="flex items-start gap-4"
+              >
+                <div className="flex items-center justify-center h-9 w-9 rounded-lg bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400 shrink-0">
+                  <Icon className="h-5 w-5" />
+                </div>
+                <div className="pt-0.5">
+                  <h3 className="font-semibold text-slate-800 dark:text-slate-200">{title}</h3>
+                  <p className="text-sm text-slate-600 dark:text-slate-400">{desc}</p>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/apps/web/components/dashboard/dubbing/DubbingMediaPlayer.tsx
+++ b/apps/web/components/dashboard/dubbing/DubbingMediaPlayer.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import { motion } from "motion/react";
+import {
+  Play, Pause, Volume2, VolumeX, Maximize, Minimize, Settings, Mic,
+} from "lucide-react";
+
+const formatTime = (time: number) => {
+  if (isNaN(time) || !isFinite(time)) return "0:00";
+  const m = Math.floor(time / 60);
+  const s = Math.floor(time % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+};
+
+type Props = {
+  url: string;
+  isVideo: boolean;
+  title?: string;
+};
+
+/**
+ * Custom media player for dubbed output — modeled on the subtitle feature's
+ * VideoPlayer (center play, custom control bar, speed menu), purple-themed and
+ * extended to render an animated surface for audio-only dubs.
+ */
+export function DubbingMediaPlayer({ url, isVideo, title }: Props) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+  const [isMuted, setIsMuted] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [showControls, setShowControls] = useState(true);
+  const [showSettings, setShowSettings] = useState(false);
+  const [playbackRate, setPlaybackRate] = useState(1);
+
+  const mediaRef = useRef<HTMLMediaElement | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const controlsTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  const togglePlay = () => {
+    const el = mediaRef.current;
+    if (!el) return;
+    if (isPlaying) el.pause();
+    else el.play();
+    setIsPlaying(!isPlaying);
+  };
+
+  const toggleMute = () => {
+    const el = mediaRef.current;
+    if (!el) return;
+    el.muted = !isMuted;
+    setIsMuted(!isMuted);
+  };
+
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = parseFloat(e.target.value);
+    setVolume(v);
+    if (mediaRef.current) {
+      mediaRef.current.volume = v;
+      mediaRef.current.muted = v === 0;
+      setIsMuted(v === 0);
+    }
+  };
+
+  const handleSeek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const pct = parseFloat(e.target.value);
+    if (mediaRef.current && duration) {
+      mediaRef.current.currentTime = (pct / 100) * duration;
+      setProgress(pct);
+    }
+  };
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      containerRef.current?.requestFullscreen();
+      setIsFullscreen(true);
+    } else {
+      document.exitFullscreen();
+      setIsFullscreen(false);
+    }
+  };
+
+  const handlePlaybackRate = (rate: number) => {
+    if (mediaRef.current) {
+      mediaRef.current.playbackRate = rate;
+      setPlaybackRate(rate);
+    }
+  };
+
+  const onTimeUpdate = () => {
+    const el = mediaRef.current;
+    if (!el) return;
+    setCurrentTime(el.currentTime);
+    setProgress((el.currentTime / el.duration) * 100 || 0);
+  };
+
+  const onLoadedMetadata = () => {
+    if (mediaRef.current) setDuration(mediaRef.current.duration);
+  };
+
+  const handleMouseMove = () => {
+    setShowControls(true);
+    if (controlsTimeout.current) clearTimeout(controlsTimeout.current);
+    if (isPlaying) controlsTimeout.current = setTimeout(() => setShowControls(false), 2500);
+  };
+
+  useEffect(() => {
+    const close = (e: MouseEvent) => {
+      if (showSettings && !(e.target as HTMLElement)?.closest?.(".settings-container")) {
+        setShowSettings(false);
+      }
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [showSettings]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative w-full ${isVideo ? "aspect-video bg-black" : "aspect-video bg-gradient-to-br from-purple-900 via-slate-900 to-indigo-900"} rounded-3xl overflow-hidden shadow-2xl ring-1 ring-white/10 group select-none`}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={() => isPlaying && setShowControls(false)}
+    >
+      {isVideo ? (
+        <video
+          ref={(el) => { mediaRef.current = el; }}
+          key={url}
+          src={url}
+          className="w-full h-full object-contain bg-black"
+          onClick={togglePlay}
+          onTimeUpdate={onTimeUpdate}
+          onLoadedMetadata={onLoadedMetadata}
+          onEnded={() => setIsPlaying(false)}
+        />
+      ) : (
+        <>
+          {/* Audio visual surface — animated equalizer that reacts to playback */}
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-6" onClick={togglePlay}>
+            <div className="flex items-end gap-1.5 h-24">
+              {[...Array(9)].map((_, i) => (
+                <motion.span
+                  key={i}
+                  className="w-2.5 rounded-full bg-gradient-to-t from-purple-500 to-indigo-400"
+                  animate={isPlaying ? { height: [16, 60 - Math.abs(4 - i) * 6, 16] } : { height: 16 }}
+                  transition={isPlaying ? { duration: 0.9, repeat: Infinity, delay: i * 0.08, ease: "easeInOut" } : { duration: 0.3 }}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-2 text-white/80">
+              <Mic className="h-4 w-4" />
+              <span className="text-sm font-medium max-w-[240px] truncate">{title || "Dubbed audio"}</span>
+            </div>
+          </div>
+          <audio
+            ref={(el) => { mediaRef.current = el; }}
+            key={url}
+            src={url}
+            onTimeUpdate={onTimeUpdate}
+            onLoadedMetadata={onLoadedMetadata}
+            onEnded={() => setIsPlaying(false)}
+          />
+        </>
+      )}
+
+      {/* Center play button */}
+      <div
+        className={`absolute inset-0 flex items-center justify-center transition-opacity duration-300 ${isPlaying ? "opacity-0 pointer-events-none" : "opacity-100"}`}
+        onClick={togglePlay}
+      >
+        <div className="w-20 h-20 bg-white/10 backdrop-blur-md rounded-full flex items-center justify-center hover:bg-purple-600/90 hover:scale-110 transition-all cursor-pointer shadow-xl ring-1 ring-white/20">
+          {isPlaying ? <Pause className="w-8 h-8 text-white fill-current" /> : <Play className="w-8 h-8 ml-1 text-white fill-current" />}
+        </div>
+      </div>
+
+      {/* Control bar */}
+      <div className={`absolute bottom-0 left-0 right-0 p-4 sm:p-6 bg-gradient-to-t from-black/90 via-black/50 to-transparent transition-opacity duration-300 ${showControls || !isPlaying ? "opacity-100" : "opacity-0"}`}>
+        {/* Timeline */}
+        <div className="relative group/timeline w-full h-1.5 mb-4 cursor-pointer flex items-center">
+          <div className="absolute w-full h-full bg-white/20 rounded-full" />
+          <div className="absolute h-full bg-purple-500 rounded-full pointer-events-none z-10" style={{ width: `${progress}%` }} />
+          <div className="absolute h-4 w-4 bg-white rounded-full shadow-lg scale-0 group-hover/timeline:scale-100 transition-transform z-20" style={{ left: `${progress}%`, transform: "translateX(-50%)" }} />
+          <input type="range" min="0" max="100" step="0.1" value={progress} onChange={handleSeek} className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-30" />
+        </div>
+
+        <div className="flex justify-between items-center text-white">
+          <div className="flex items-center gap-4">
+            <button onClick={togglePlay} className="hover:text-purple-400 transition-colors">
+              {isPlaying ? <Pause className="w-5 h-5 sm:w-6 sm:h-6 fill-current" /> : <Play className="w-5 h-5 sm:w-6 sm:h-6 fill-current" />}
+            </button>
+
+            <div className="flex items-center gap-2 group/volume">
+              <button onClick={toggleMute} className="hover:text-purple-400 transition-colors">
+                {isMuted || volume === 0 ? <VolumeX className="w-5 h-5" /> : <Volume2 className="w-5 h-5" />}
+              </button>
+              <input
+                type="range" min="0" max="1" step="0.05"
+                value={isMuted ? 0 : volume}
+                onChange={handleVolumeChange}
+                className="w-0 overflow-hidden group-hover/volume:w-20 transition-all duration-300 h-1 bg-white/30 rounded-lg appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:rounded-full"
+              />
+            </div>
+
+            <span className="text-xs font-mono opacity-80 select-none">
+              {formatTime(currentTime)} / {formatTime(duration)}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-4 relative settings-container">
+            {showSettings && (
+              <div className="absolute bottom-12 right-0 bg-black/90 border border-white/10 backdrop-blur-md rounded-xl p-3 w-48 shadow-2xl z-50">
+                <p className="text-xs font-semibold text-slate-400 px-2 py-1 mb-1 uppercase tracking-wider">Speed</p>
+                <div className="grid grid-cols-4 gap-1">
+                  {[0.5, 1, 1.5, 2].map((rate) => (
+                    <button
+                      key={rate}
+                      onClick={() => handlePlaybackRate(rate)}
+                      className={`text-xs font-medium py-1.5 rounded-md transition-colors hover:bg-white/20 ${playbackRate === rate ? "bg-purple-600 text-white shadow-lg shadow-purple-500/20" : "bg-white/5 text-slate-300"}`}
+                    >
+                      {rate}x
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <button
+              onClick={() => setShowSettings(!showSettings)}
+              className={`transition-all duration-300 ${showSettings ? "text-purple-400 rotate-90" : "text-white hover:text-purple-400"}`}
+            >
+              <Settings className="w-5 h-5" />
+            </button>
+
+            {isVideo && (
+              <button onClick={toggleFullscreen} className="hover:text-purple-400 transition-colors text-white">
+                {isFullscreen ? <Minimize className="w-5 h-5" /> : <Maximize className="w-5 h-5" />}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/dubbing/DubbingVoiceAnimation.tsx
+++ b/apps/web/components/dashboard/dubbing/DubbingVoiceAnimation.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { motion } from "motion/react";
+
+/**
+ * Animated voice/mic hero — the dubbing analogue of AI Studio's animated bot.
+ * A floating microphone with pulsing sound rings and a live equalizer.
+ */
+export function DubbingVoiceAnimation() {
+  const bars = [
+    { x: 44, base: 82, h: 14, d: 0.4 },
+    { x: 54, base: 74, h: 30, d: 0.15 },
+    { x: 64, base: 80, h: 18, d: 0 },
+    { x: 132, base: 80, h: 18, d: 0 },
+    { x: 142, base: 72, h: 32, d: 0.2 },
+    { x: 152, base: 82, h: 14, d: 0.45 },
+  ];
+
+  return (
+    <div className="flex justify-center">
+      <motion.svg
+        width="176"
+        height="176"
+        viewBox="0 0 200 200"
+        fill="none"
+        role="img"
+        aria-label="Animated microphone"
+        animate={{ y: [0, -8, 0] }}
+        transition={{ duration: 3.5, repeat: Infinity, ease: "easeInOut" }}
+      >
+        <defs>
+          <linearGradient id="dubMicGrad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#a855f7" />
+            <stop offset="100%" stopColor="#6366f1" />
+          </linearGradient>
+        </defs>
+
+        {/* Pulsing sound rings */}
+        {[0, 1, 2].map((i) => (
+          <motion.circle
+            key={i}
+            cx="100"
+            cy="82"
+            r="42"
+            stroke="#a855f7"
+            strokeWidth="2"
+            fill="none"
+            style={{ transformBox: "fill-box", transformOrigin: "center" }}
+            initial={{ scale: 0.5, opacity: 0 }}
+            animate={{ scale: [0.5, 1.5], opacity: [0.5, 0] }}
+            transition={{ duration: 2.4, repeat: Infinity, delay: i * 0.8, ease: "easeOut" }}
+          />
+        ))}
+
+        {/* Soft glow */}
+        <circle cx="100" cy="82" r="38" fill="url(#dubMicGrad)" opacity="0.12" />
+
+        {/* Mic capsule + grille */}
+        <rect x="86" y="46" width="28" height="56" rx="14" fill="url(#dubMicGrad)" />
+        <line x1="92" y1="60" x2="108" y2="60" stroke="white" strokeOpacity="0.55" strokeWidth="1.5" />
+        <line x1="92" y1="70" x2="108" y2="70" stroke="white" strokeOpacity="0.55" strokeWidth="1.5" />
+        <line x1="92" y1="80" x2="108" y2="80" stroke="white" strokeOpacity="0.55" strokeWidth="1.5" />
+
+        {/* Holder + stand */}
+        <path d="M74 84 a26 26 0 0 0 52 0" stroke="url(#dubMicGrad)" strokeWidth="5" fill="none" strokeLinecap="round" />
+        <line x1="100" y1="110" x2="100" y2="132" stroke="url(#dubMicGrad)" strokeWidth="5" strokeLinecap="round" />
+        <line x1="84" y1="132" x2="116" y2="132" stroke="url(#dubMicGrad)" strokeWidth="5" strokeLinecap="round" />
+
+        {/* Live equalizer bars flanking the mic */}
+        {bars.map((b, i) => (
+          <motion.rect
+            key={i}
+            x={b.x}
+            width="5"
+            rx="2.5"
+            fill="url(#dubMicGrad)"
+            initial={{ height: 8, y: b.base }}
+            animate={{ height: [8, b.h, 8], y: [b.base, b.base - (b.h - 8), b.base] }}
+            transition={{ duration: 1.1, repeat: Infinity, delay: b.d, ease: "easeInOut" }}
+          />
+        ))}
+      </motion.svg>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/main/types.ts
+++ b/apps/web/components/dashboard/main/types.ts
@@ -1,4 +1,4 @@
-import { PlaySquare, Lightbulb, Image as ImageIcon, MessageSquare, Globe, PenTool, LayoutTemplate, Brain } from "lucide-react";
+import { PlaySquare, Lightbulb, Image as ImageIcon, MessageSquare, Globe, PenTool, LayoutTemplate, Mic } from "lucide-react";
 import type { DashboardData } from "@/app/dashboard/page";
 
 export interface DashboardHomeProps {
@@ -36,7 +36,7 @@ export const QUICK_ACTIONS = [
   { label: "Create Thumbnail", icon: ImageIcon, href: "/dashboard/thumbnails/new" },
   { label: "Add Subtitles", icon: MessageSquare, href: "/dashboard/subtitles/new" },
   { label: "Build Story", icon: LayoutTemplate, href: "/dashboard/story-builder/new" },
-  { label: "Ideate Content", icon: Brain, href: "/dashboard/research" },
+  { label: "Audio Dubbing", icon: Mic, href: "/dashboard/dubbing/new" },
 ] as const;
 
 export const ACTIVITY_ICONS: Record<string, { icon: any; color: string }> = {

--- a/apps/web/components/dashboard/sidebar/dashboard-sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/dashboard-sidebar.tsx
@@ -172,7 +172,7 @@ export function DashboardSidebar({ collapsed, setCollapsed, pinned, setPinned }:
     { label: "Subtitles", icon: <MessageSquareIcon className="h-4 w-4" />, variant: "ghost", href: "/dashboard/subtitles" },
     { label: "Video Generation", icon: <Video className="h-4 w-4" />, variant: "ghost", href: "/dashboard/video-generation", badge: "Soon", locked: true },
     { label: "Course Builder", icon: <BookOpenIcon className="h-4 w-4" />, variant: "ghost", href: "/dashboard/courses", badge: "Soon", locked: true },
-    { label: "Audio Dubbing", icon: <MicIcon className="h-4 w-4" />, variant: "ghost", href: "/dashboard/dubbing", badge: "Soon", locked: true },
+    { label: "Audio Dubbing", icon: <MicIcon className="h-4 w-4" />, variant: "ghost", href: "/dashboard/dubbing" },
   ]
 
   const links: ReadonlyArray<NavLink> = baseLinks

--- a/apps/web/hooks/useDubbing.ts
+++ b/apps/web/hooks/useDubbing.ts
@@ -1,14 +1,41 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
+import axios from "axios";
 import { toast } from "sonner";
 import { DubbedResult, DubbingProgress, supportedLanguages } from "@repo/validation";
 import { api, getApiErrorMessage } from "@/lib/api-client";
 import { useSupabase } from "@/components/supabase-provider";
 import { BACKEND_URL } from "@/lib/constants";
 
+const MAX_UPLOAD_BYTES = 500 * 1024 * 1024;
+
+// BullMQ SSE state → the UI's DubbingProgress state.
+function mapState(state: string): DubbingProgress["state"] {
+  if (state === "completed") return "completed";
+  if (state === "failed") return "failed";
+  return "processing"; // waiting | active
+}
+
+// Read duration client-side — the API needs it to price the job (credits/sec).
+function getMediaDuration(file: File): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const el = document.createElement(file.type.startsWith("video/") ? "video" : "audio");
+    el.preload = "metadata";
+    el.onloadedmetadata = () => {
+      URL.revokeObjectURL(el.src);
+      resolve(el.duration || 0);
+    };
+    el.onerror = () => {
+      URL.revokeObjectURL(el.src);
+      reject(new Error("Could not read media metadata. The file may be corrupt."));
+    };
+    el.src = URL.createObjectURL(file);
+  });
+}
+
 export function useDubbing() {
-  const { supabase, session } = useSupabase();
+  const { session } = useSupabase();
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [mediaFile, setMediaFile] = useState<File | null>(null);
@@ -17,38 +44,59 @@ export function useDubbing() {
   const [mediaName, setMediaName] = useState("");
   const [dubbedResult, setDubbedResult] = useState<DubbedResult | null>(null);
 
+  const [allowed, setAllowed] = useState(false);
+  const [accessLoading, setAccessLoading] = useState(true);
+
+  // Mid-run cancellation: the BullMQ job id of the in-flight dub, and whether the
+  // user asked to cancel (suppresses the generic failure toast).
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const cancelRequestedRef = useRef(false);
+
   const [progress, setProgress] = useState<DubbingProgress>({
     state: "idle",
     progress: 0,
     message: "",
   });
 
+  // Plan gate: Pro/Business/Scale only.
+  useEffect(() => {
+    api
+      .get<{ allowed: boolean }>("/api/v1/dubbing/access", { requireAuth: true })
+      .then((res) => setAllowed(!!res.allowed))
+      .catch(() => setAllowed(false))
+      .finally(() => setAccessLoading(false));
+  }, []);
+
   const updateProgress = useCallback(
-    (state: DubbingProgress["state"], progress: number, message: string) => {
-      setProgress({ state, progress, message });
+    (state: DubbingProgress["state"], value: number, message: string) => {
+      setProgress({ state, progress: value, message });
     },
-    []
+    [],
   );
 
-  const handleFileChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
+  // Shared by the file input and the drag-and-drop zone.
+  const handleFileSelect = useCallback((file: File | null | undefined) => {
+    if (!file) return;
 
-      if (file.size > 500 * 1024 * 1024) {
-        toast.error("File too large", {
-          description: "Please upload a file smaller than 500MB.",
-        });
-        return;
-      }
+    if (!/^(audio|video)\//.test(file.type)) {
+      toast.error("Unsupported file", { description: "Please upload an audio or video file." });
+      return;
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      toast.error("File too large", { description: "Please upload a file smaller than 500MB." });
+      return;
+    }
 
-      setIsVideo(file.type.startsWith("video/"));
-      setMediaFile(file);
-      setDubbedResult(null);
-      setProgress({ state: "idle", progress: 0, message: "" });
-    },
-    []
-  );
+    setIsVideo(file.type.startsWith("video/"));
+    setMediaFile(file);
+    setDubbedResult(null);
+    setProgress({ state: "idle", progress: 0, message: "" });
+  }, []);
+
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFileSelect(e.target.files?.[0]);
+    if (fileInputRef.current) fileInputRef.current.value = ""; // allow re-selecting the same file
+  }, [handleFileSelect]);
 
   const resetForm = useCallback(() => {
     setMediaFile(null);
@@ -70,92 +118,113 @@ export function useDubbing() {
     let eventSource: EventSource | null = null;
 
     try {
-      updateProgress("uploading", 5, "Uploading media...");
+      const durationSeconds = await getMediaDuration(mediaFile);
+      if (!durationSeconds) throw new Error("Could not determine media duration.");
 
-      const filePath = `${crypto.randomUUID()}-${mediaFile.name}`;
-
-      const { error: uploadError } = await supabase.storage
-        .from("dubbing_media")
-        .upload(filePath, mediaFile, { upsert: true });
-
-      if (uploadError) throw new Error(uploadError.message);
-
-      const { data } = supabase.storage
-        .from("dubbing_media")
-        .getPublicUrl(filePath);
-
-      if (!data.publicUrl) throw new Error("Failed to generate media URL");
-
-      updateProgress("uploading", 10, "Upload complete. Starting dubbing...");
-
-      // Create dubbing job
-      const response = await api.post<{ projectId: string }>(
-        "/api/v1/dubbing",
+      // 1. Signed URL — plan-gated + size-checked server-side before it's issued.
+      updateProgress("uploading", 5, "Preparing upload...");
+      const { uploadUrl, objectName, contentType } = await api.post<{
+        uploadUrl: string;
+        objectName: string;
+        contentType: string;
+      }>(
+        "/api/v1/dubbing/sign-upload",
         {
-          mediaUrl: data.publicUrl,
-          targetLanguage,
+          filename: mediaFile.name,
+          contentType: mediaFile.type || (isVideo ? "video/mp4" : "audio/mpeg"),
+          fileSize: mediaFile.size,
           isVideo,
-          mediaName: mediaName.trim(),
+          durationSeconds,
         },
-        {
-          requireAuth: true,
-          accessToken: session?.access_token,
-        }
+        { requireAuth: true, accessToken: session?.access_token },
       );
 
-      const { projectId } = response;
+      // 2. Upload straight to GCS (no API in the byte path).
+      await axios.put(uploadUrl, mediaFile, {
+        headers: { "Content-Type": contentType },
+        onUploadProgress: (e) => {
+          const pct = Math.round((e.loaded * 100) / (e.total || 1));
+          updateProgress("uploading", Math.min(15, 5 + pct * 0.1), `Uploading media... ${pct}%`);
+        },
+      });
 
-      // Connect to SSE for status updates
-      eventSource = new EventSource(
-        `${BACKEND_URL}/api/v1/dubbing/status/${projectId}`
+      // 3. Create the dubbing job.
+      updateProgress("processing", 15, "Upload complete. Starting dubbing...");
+      const { jobId } = await api.post<{ projectId: string; jobId: string }>(
+        "/api/v1/dubbing",
+        { objectName, targetLanguage, isVideo, mediaName: mediaName.trim(), durationSeconds },
+        { requireAuth: true, accessToken: session?.access_token },
       );
 
+      // 4. Stream job status via SSE (BullMQ-backed).
+      cancelRequestedRef.current = false;
+      setActiveJobId(jobId);
+      eventSource = new EventSource(`${BACKEND_URL}/api/v1/dubbing/status/${jobId}`);
       eventSource.onmessage = (event) => {
-        const data: DubbingProgress = JSON.parse(event.data);
-        setProgress(data);
+        const data = JSON.parse(event.data) as {
+          state: string;
+          progress: number;
+          message: string;
+          finished: boolean;
+          error?: string;
+          dubbedUrl?: string;
+        };
+
+        updateProgress(mapState(data.state), data.progress, data.message);
 
         if (data.finished) {
           eventSource?.close();
+          setActiveJobId(null);
 
           if (data.state === "completed") {
-            // Fetch the final result with dubbed URL
-            api.get<DubbedResult>(`/api/v1/dubbing/${projectId}`, {
-              requireAuth: true,
-              accessToken: session?.access_token,
-            }).then((result) => {
-              setDubbedResult({
-                projectId: result.projectId,
-                dubbedUrl: result.dubbedUrl,
-                targetLanguage,
-              });
-            });
-
+            setDubbedResult({ projectId: "", dubbedUrl: data.dubbedUrl, targetLanguage });
             toast.success("Dubbing complete 🎉", {
-              description: `Dubbed into ${supportedLanguages.find((l) => l.value === targetLanguage)?.label
-                }${data.creditsUsed ? ` (${data.creditsUsed} credits used)` : ""}`,
+              description: `Your media was dubbed into ${supportedLanguages.find((l) => l.value === targetLanguage)?.label ?? targetLanguage}.`,
             });
           } else if (data.state === "failed") {
-            toast.error("Dubbing failed", { description: data.message });
+            if (cancelRequestedRef.current || (data.error || "").includes("cancelled")) {
+              updateProgress("failed", 0, "Cancelled");
+              toast.info("Dubbing cancelled", { description: "No credits were charged." });
+            } else {
+              toast.error("Dubbing failed", { description: data.error || data.message });
+            }
           }
         }
       };
 
       eventSource.onerror = () => {
         eventSource?.close();
+        setActiveJobId(null);
         updateProgress("failed", 0, "Connection lost");
         toast.error("Connection lost", { description: "Please try again" });
       };
     } catch (error) {
       eventSource?.close();
+      setActiveJobId(null);
       const message = getApiErrorMessage(error, "Dubbing failed.");
-
       updateProgress("failed", 0, message);
       toast.error("Error dubbing media", { description: message });
     }
-  }, [mediaFile, targetLanguage, isVideo, mediaName, supabase, session, updateProgress]);
+  }, [mediaFile, targetLanguage, isVideo, mediaName, session, updateProgress]);
 
-  const isLoading =
-    progress.state === "uploading" || progress.state === "processing";
+  /** Cancel the in-flight dub: queued jobs stop instantly, active ones abort between stages. */
+  const cancelDub = useCallback(async () => {
+    if (!activeJobId) return;
+    cancelRequestedRef.current = true;
+    try {
+      const res = await api.post<{ message: string }>(
+        `/api/v1/dubbing/stop/${activeJobId}`,
+        {},
+        { requireAuth: true, accessToken: session?.access_token },
+      );
+      toast.info(res.message);
+    } catch (error) {
+      cancelRequestedRef.current = false;
+      toast.error("Could not cancel", { description: getApiErrorMessage(error, "Please try again.") });
+    }
+  }, [activeJobId, session]);
+
+  const isLoading = progress.state === "uploading" || progress.state === "processing";
 
   return {
     fileInputRef,
@@ -168,7 +237,12 @@ export function useDubbing() {
     dubbedResult,
     progress,
     isLoading,
+    allowed,
+    accessLoading,
+    canCancel: !!activeJobId,
+    cancelDub,
     handleFileChange,
+    handleFileSelect,
     resetForm,
     handleDubMedia,
   };

--- a/apps/web/lib/api/getDubbings.ts
+++ b/apps/web/lib/api/getDubbings.ts
@@ -8,7 +8,7 @@ export interface DubbingProject {
   user_id: string
   original_media_url: string
   target_language: string
-  status: "dubbing" | "dubbed"
+  status: "queued" | "processing" | "cloning" | "completed" | "failed"
   is_video: boolean
   dubbedUrl?: string
   credits_consumed?: number
@@ -56,5 +56,17 @@ export async function deleteDubbing(
   } catch {
     return false
   }
+}
+
+/** Re-run a dub with the same source + target language (reuses the stored GCS object). */
+export async function regenerateDubbing(
+  projectId: string,
+  accessToken?: string
+): Promise<{ projectId: string; jobId: string }> {
+  return api.post<{ projectId: string; jobId: string }>(
+    `/api/v1/dubbing/${projectId}/regenerate`,
+    {},
+    { requireAuth: true, accessToken },
+  )
 }
 

--- a/docs/dubbing-design.md
+++ b/docs/dubbing-design.md
@@ -1,0 +1,377 @@
+# Audio Dubbing — System Design
+
+Voice-preserving dubbing for Creator AI: a creator uploads audio (or video), we
+transcribe + translate the speech with **Gemini on Vertex AI**, clone the
+speaker's voice, and synthesize the translation **in their own voice** in the
+target language. Gated to **all paid plans** (Creator, Pro, Business, Scale) —
+only Starter (free) is excluded.
+
+> Pipeline = Vertex (transcribe + translate, already used everywhere) →
+> serverless GPU voice clone (Modal) → store result. No single Google product
+> does identity-preserving cross-lingual TTS; the true open models that do
+> (XTTS, Meta Seamless) are non-commercial-licensed, so the clone step is a
+> self-hosted **MIT-licensed** model behind an HTTP endpoint. See §5.
+
+## 0. What already exists (and why it must change)
+
+There is a **working prototype** in `apps/api/src/dubbing/` (`dubbing.service.ts`,
+`dubbing.controller.ts`, `dubbing.module.ts`) plus a `dubbing_projects` table and
+a `dubbing_media` Supabase Storage bucket. It already does: Gemini
+transcribe+translate, ffmpeg audio extraction, a call to a Modal `/dub`
+endpoint (VoxCPM), and credit deduction.
+
+It is a **v0 prototype, not a scalable paid feature.** The gaps that this design
+closes:
+
+| Prototype today | Problem for a paid, scalable feature | Fix |
+|---|---|---|
+| `void this.processDub(...)` — fire-and-forget **inside the API process** | A worker restart/crash silently loses the job. No retry, no isolation, buffers media in API RAM. | Move to a **BullMQ `dubbing` queue + worker**, exactly like `video-generation.processor.ts`. |
+| **No plan gate** — any user with 10 credits can dub | Feature must be Pro/Business/Scale only | `canDub(planName)` gate, server-authoritative (mirror `canGenerateVideo`). |
+| Gemini fed **inline base64, 50MB cap** | Long/large media rejected; base64 inflates RAM ~33% | Upload to **GCS**, let Vertex read the `gs://` URI directly (lifts to 2GB — same move already made for subtitles). |
+| **Flat 10-credit** cost per dub | GPU cost scales with audio length; flat pricing loses money at scale | **Duration-based** credits (per second of audio). |
+| SSE polls the DB status every 2.5s | Diverges from the BullMQ SSE every other feature uses | Reuse `createJobSSE` off the BullMQ job. |
+| VoxCPM (EN/ZH-leaning) | Weak for 23-language cross-lingual dubbing | Swap the model behind Modal to **Chatterbox Multilingual (MIT, 23 langs)**. Endpoint contract unchanged. |
+| Video in → **audio-only** out | "Same video in another language" needs video out | v1.5 stage: mux dubbed audio back over the video (§8). |
+
+## 1. Where it fits (existing patterns reused)
+
+| Concern | Reuse of | Notes |
+|---|---|---|
+| Async long job | **BullMQ** queue + `WorkerHost` (`video-generation`, `thumbnail`) | Clone step is a 30s–3min GPU call — must be a background job, never inline in the API. |
+| Direct upload | `SubtitleService.signUpload` / `finalizeUpload` (signed GCS PUT) | Browser PUTs straight to GCS; API never touches the bytes. Plan-based size/duration caps enforced here. |
+| Transcribe + translate | `SubtitleService.create` Gemini call via `gs://` `fileData` | Vertex reads media from GCS — no inline 50MB ceiling. Same `createGoogleAI` client. |
+| Voice clone (GPU) | existing Modal `/dub` endpoint | Serverless GPU, pay-per-second, autoscales to zero — ideal for bursty dubbing load. |
+| SSE progress | `createJobSSE` (`common/sse`) | Worker `job.updateProgress()` → browser. Replaces the DB-poll SSE. |
+| Credits | `update_user_credits` RPC + `calculateDubbingCredits` | Change to duration-based (§5). |
+| Plan gating | `getActivePlanName` in `VideoGenerationService` | Same `subscriptions → plans(name)` query; allow Pro/Business/Scale. |
+| Storage | `dubbing_media` Supabase bucket (output), GCS (input) | Input on GCS (Vertex needs `gs://`); output stays Supabase (small WAV/MP4). |
+
+No new dependencies. `@nestjs/bullmq`, `@google/genai`, `@google-cloud/storage`,
+`fluent-ffmpeg` are all already installed and used.
+
+## 2. Data flow
+
+```
+Browser (Pro / Business / Scale)
+  │  1. POST /dubbing/sign-upload { filename, contentType, fileSize, isVideo, durationSeconds }
+  │        → API plan-gates + caps → returns { uploadUrl, objectName }
+  │  2. PUT file → GCS (signed URL, direct, no API in the byte path)
+  │  3. POST /dubbing { objectName, targetLanguage, isVideo, mediaName, durationSeconds }
+  ▼
+API: DubbingController → DubbingService.createDub()
+  │   a. plan gate  → 403 if not Pro/Business/Scale
+  │   b. verify GCS object + real size/duration (mirror finalizeUpload)
+  │   c. credit precheck (duration floor) → 403 if short
+  │   d. insert dubbing_projects (status='queued')
+  │   e. queue.add('dubbing', { userId, projectId, inputGsUri, targetLanguage, isVideo, durationSeconds }, { jobId })
+  ▼  returns { projectId, jobId }
+Browser opens SSE  GET /dubbing/status/:jobId   (createJobSSE)
+  ▼
+Worker: DubbingProcessor.process()          [packages/workers]
+  │   1. status='processing'  (progress 5)
+  │   2. Gemini (Vertex, gs:// fileData): transcribe + translate → target text   (progress 30)
+  │   3. download media from GCS → ffmpeg extract clean reference WAV            (progress 45)
+  │   4. status='cloning'; POST Modal /dub { text, reference } → dubbed WAV      (progress 80)
+  │   5. (if isVideo) ffmpeg mux dubbed audio over original video → MP4          (progress 90)
+  │   6. upload result → dubbing_media (Supabase); deduct duration-based credits
+  │   7. status='completed', dubbed_url persisted                               (progress 100)
+  ▼
+SSE emits completed → browser plays the dubbed media
+```
+
+Failure at any stage → `status='failed'`, `error_message` persisted, SSE emits
+`failed`. BullMQ `attempts: 1` (same default as the other queues — no
+auto-retry of a paid GPU call; the user re-submits).
+
+## 3. Model & cost
+
+### The clone model (behind Modal)
+
+The endpoint contract (`POST MODAL_API_URL` with `text` + `reference` audio →
+dubbed audio) stays; only the model loaded in the Modal image changes. Modal
+gives each deployed web endpoint its own dedicated hostname — `MODAL_API_URL`
+is that exact printed URL, not a base URL with a `/dub` path appended.
+
+- **Recommended: Chatterbox Multilingual** (Resemble AI) — **MIT license**,
+  23 languages, 5-second zero-shot clone, built-in watermarking (helps the
+  consent/deepfake story). Commercial-safe to ship.
+- Current: VoxCPM — fine for a demo, weak cross-lingual. Swap it.
+- Rejected: Coqui XTTS-v2 and Meta SeamlessExpressive are technically better at
+  cross-lingual but are **non-commercial licensed** — cannot ship in a paid
+  product.
+
+### Why Modal, not AWS/GCP GPU
+
+Dubbing load is spiky (a Pro user dubs a few clips, then nothing for hours).
+Modal is **serverless GPU billed per-second, scales to zero** — you pay only
+while a clone runs. A dedicated GCP/AWS GPU VM bills 24/7 whether used or not.
+
+> **On the $100 AWS credit:** not worth architecting around. $100 ≈ a few dozen
+> GPU-hours — too little to base a serving tier on, and S3 output is useless
+> here because Vertex reads `gs://` only (see the S3-vs-GCS note). Keep the GPU
+> on Modal; keep media on GCS/Supabase. Spend the AWS credit elsewhere.
+
+### Credits (duration-based)
+
+Cost scales with audio length (GPU time ∝ seconds of speech), so bill by the
+second, not a flat 10:
+
+```ts
+// consts/credits.ts — replace the flat externalCreditsUsed model
+export const DUBBING_CREDIT_MULTIPLIER = 15; // credits per second of source audio
+export function calculateDubbingCreditsByDuration(
+  durationSeconds: number,
+  multiplier = DUBBING_CREDIT_MULTIPLIER,
+): number {
+  return Math.max(multiplier, Math.ceil(durationSeconds) * multiplier);
+}
+export function getMinimumCreditsForDubbing(multiplier = DUBBING_CREDIT_MULTIPLIER): number {
+  return multiplier; // one-second floor for the enqueue precheck
+}
+```
+
+Precheck the floor before enqueue (fast 403); the worker deducts the real
+duration-based cost after a successful clone — never charge for a failed job.
+Tune `DUBBING_CREDIT_MULTIPLIER` via env, no redeploy. (Numbers illustrative —
+calibrate against a measured Modal cost-per-second once Chatterbox is loaded.)
+
+## 4. Plan gating (all paid plans — only Starter excluded)
+
+Plans are Starter (free) · **Creator ($24)** · **Pro ($49)** · **Business ($299)** ·
+**Scale ($599)**. Dubbing is included in every paid plan. Gate by plan **name**
+(there is no tier column — the active plan is the most-recent active
+`subscriptions` row):
+
+```ts
+// consts/dubbing.ts
+export const DUBBING_PLANS = ['creator', 'pro', 'business', 'scale'] as const;
+export function canDub(planName?: string | null): boolean {
+  if (!planName) return false;
+  return DUBBING_PLANS.includes(planName.toLowerCase() as (typeof DUBBING_PLANS)[number]);
+}
+```
+
+Server-side check in `DubbingService.signUpload`/`createDub` is authoritative;
+the client gate (`GET /dubbing/access`) is UX only — the new-dub page shows an
+upgrade card to Starter users.
+
+## 5. Storage
+
+- **Input** → dedicated GCS bucket **`GCS_DUBBING_BUCKET`** (separate from
+  subtitles so retention/cleanup can diverge). Vertex transcribes from the
+  `gs://` URI; Modal fetches the public URL as the voice reference. The shared
+  `gcs.ts` helpers take an optional `bucket` argument, so no code duplication.
+  See §9.1 for the bucket setup guide.
+- **Output** → keep the existing `dubbing_media` Supabase Storage bucket. Output
+  is a small WAV; Supabase public URL is already wired. No reason to move it.
+- Delete cleans up the GCS input object on `DELETE /dubbing/:id`.
+
+## 5b. Cancellation (train-ai pattern)
+
+`POST /dubbing/stop/:jobId`:
+- **queued** job → removed from BullMQ outright, row marked `failed`
+  (`Cancelled by user`).
+- **active** job → Redis flag `dubbing:cancel:<jobId>` (TTL 1h); the worker
+  checks it **between stages** (before Gemini, before Modal, before
+  upload/credits) and aborts. Credits are only deducted after the last
+  checkpoint, so a cancelled dub never charges.
+
+The UI shows a **Cancel Dubbing** button while a job is in flight; on cancel
+the SSE stream ends `failed` and the client shows "Dubbing cancelled — no
+credits were charged."
+
+## 6. Files to add / change
+
+**packages/validations**
+- `consts/dubbing.ts` — `DUBBING_PLANS`, `canDub`, `DUBBING_CREDIT_MULTIPLIER`,
+  `calculateDubbingCreditsByDuration`, `getMinimumCreditsForDubbing`, allowed
+  target languages / accents list.
+- `consts/credits.ts` — deprecate flat `calculateDubbingCredits` in favor of the
+  duration fn (keep the old export until callers migrate).
+- `schema/dubbing.schema.ts` — `SignDubUploadSchema`, `CreateDubSchema`
+  (objectName, targetLanguage, isVideo, mediaName, durationSeconds) + inferred
+  types. Replace the hand-written Swagger body in the controller.
+- barrel exports in `consts/index.ts`, `schema/index.ts`.
+
+**packages/supabase**
+- `migrations/<ts>_dubbing_jobs_align.sql` — add to `dubbing_projects`:
+  `job_id text` (BullMQ), `input_gs_uri text`, `duration_seconds int`,
+  and widen the status check to
+  `('queued','processing','cloning','completed','failed')`. Keep RLS as-is
+  (worker uses service-role key).
+
+**apps/api/src/dubbing/**
+- `dubbing.module.ts` — add `BullModule.registerQueue({ name: 'dubbing' })`,
+  `ConfigModule`.
+- `dubbing.service.ts` — **remove `processDub` (the whole inline pipeline moves
+  to the worker)**; add `signUpload`, plan gate, GCS verify, duration precheck,
+  enqueue, `getAccess`. Keep `listDubs`/`getDub`/`deleteDub` (+ GCS cleanup).
+- `dubbing.controller.ts` — add `POST /dubbing/sign-upload`, `GET /dubbing/access`;
+  switch `Sse('status/:jobId')` to `createJobSSE`; validate bodies with the Zod
+  pipe instead of inline Swagger schemas.
+
+**packages/workers/src/**
+- `processor/dubbing.processor.ts` — `@Processor('dubbing', { concurrency: 2 })`;
+  the pipeline from §2 (Gemini gs:// transcribe+translate → ffmpeg reference →
+  Modal clone → optional video mux → upload → deduct credits). Mirror
+  `video-generation.processor.ts` structure (progress, `updateJob`, env helpers).
+- `worker.module.ts` — register `DubbingProcessor` + `{ name: 'dubbing' }`.
+- reuse `processor/utils/genai.ts` (`getGenAI`) and the ffmpeg helper.
+
+**apps/web/**
+- `app/dashboard/dubbing/page.tsx` — uploader + target-language picker +
+  history + player; upgrade card when `!canDub`.
+- `components/dashboard/dubbing/*` — upload form, history list, player, upgrade card.
+- `hooks/useDubbing.ts` — sign→PUT→create + `useSSE` for progress/result
+  (mirror the subtitle uploader + `useVideoGeneration`).
+- `lib/api/getDubs.ts` — list fetch.
+
+**Env / infra**
+- `MODAL_API_URL` (already referenced) → point at the Chatterbox Modal app.
+- `GCS_DUBBING_BUCKET` (or reuse `GCS_SUBTITLE_BUCKET`), `DUBBING_CREDIT_MULTIPLIER`.
+- Modal app: load Chatterbox Multilingual, expose `POST /dub`.
+
+## 7. Build order (each step independently compilable)
+
+1. **validations** — plan gating, duration credits, schema, language list. (No runtime deps.)
+2. **migration** — align `dubbing_projects` (job_id, input_gs_uri, duration, status enum).
+3. **Modal** — swap VoxCPM → Chatterbox behind the same `/dub` contract; verify with a curl.
+4. **worker processor** — the pipeline (the core; carries the one non-trivial branch).
+5. **api** — service (gate + sign + enqueue) + controller (+ createJobSSE) + module wiring.
+6. **frontend** — page, uploader, hook, upgrade card.
+7. **env + copy** — buckets, multiplier, fix the plan `features` marketing copy.
+
+The worker processor is the only non-trivial logic → it gets a small runnable
+self-check (assert the Modal response decodes to non-empty audio; assert credits
+= `ceil(seconds) * multiplier`).
+
+## 9. Local testing guide
+
+### 9.1 One-time setup — GCS dubbing bucket
+
+Dubbing has its own bucket. Create it once (replace `creator-ai-dubbing` and the
+service-account email with yours):
+
+```bash
+# 1. Create the bucket (same project/region as Vertex)
+gcloud storage buckets create gs://creator-ai-dubbing \
+  --project=creator-ai-498712 --location=us-central1 \
+  --uniform-bucket-level-access
+
+# 2. Public read (playback + Modal fetches the reference by URL)
+gcloud storage buckets add-iam-policy-binding gs://creator-ai-dubbing \
+  --member=allUsers --role=roles/storage.objectViewer
+
+# 3. Let the Vertex service account write/read/delete objects
+gcloud storage buckets add-iam-policy-binding gs://creator-ai-dubbing \
+  --member="serviceAccount:<vertex-sa>@creator-ai-498712.iam.gserviceaccount.com" \
+  --role=roles/storage.objectAdmin
+
+# 4. CORS so the browser can PUT to the signed URL
+cat > cors.json <<'EOF'
+[{"origin": ["http://localhost:3000"], "method": ["PUT", "GET"],
+  "responseHeader": ["Content-Type"], "maxAgeSeconds": 3600}]
+EOF
+gcloud storage buckets update gs://creator-ai-dubbing --cors-file=cors.json
+```
+
+> Signed URLs require the SA key file (`GOOGLE_APPLICATION_CREDENTIALS`) or
+> `iam.serviceAccounts.signBlob` on an attached SA — same requirement as the
+> subtitle uploader.
+
+Also ensure the **Supabase** Storage bucket `dubbing_media` exists and is public
+(worker uploads the dubbed WAV there).
+
+### 9.2 One-time setup — Modal + env + DB
+
+```bash
+pip install modal && modal setup
+modal deploy modal/dubbing_app.py          # prints the /dub endpoint URL
+```
+
+Root `.env`:
+
+```
+GCS_DUBBING_BUCKET=creator-ai-dubbing
+MODAL_API_URL=https://<workspace>--creator-ai-dubbing-dub.modal.run
+# DUBBING_CREDIT_MULTIPLIER=15
+```
+
+Apply the migration (adds `job_id`, `input_gs_uri`, `input_url`,
+`duration_seconds`, new status enum):
+
+```bash
+supabase db push        # or your usual migration flow
+```
+
+Give the test user a **paid plan** (Creator or higher — the most-recent active
+`subscriptions` row) and enough `profiles.credits` (60s clip ≈ 900 credits at
+the default 15/sec).
+
+### 9.3 Run the stack
+
+```bash
+pnpm --filter api dev              # NestJS API :8000
+pnpm --filter @repo/workers dev    # BullMQ worker
+pnpm --filter web dev              # Next.js :3000
+```
+
+### 9.4 Automated tests
+
+```bash
+# Pure-logic self-check (plan gate incl. Creator, duration credits, schemas)
+npx tsx packages/validations/src/consts/dubbing.check.ts
+
+# API service tests (gate, sign-upload limits, enqueue, cancellation)
+cd apps/api && npx jest src/dubbing
+```
+
+### 9.5 Swagger (manual API testing)
+
+Open `http://localhost:8000/api/docs` (Swagger UI). The `dubbing` tag documents all
+endpoints with request bodies. Flow: `POST /dubbing/sign-upload` → PUT the file
+to `uploadUrl` (curl/Postman, matching Content-Type) → `POST /dubbing` →
+watch `GET /dubbing/status/{jobId}` (SSE) → `GET /dubbing/{id}`.
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /dubbing/access` | plan gate check (`allowed`, `plan`) |
+| `POST /dubbing/sign-upload` | signed GCS PUT URL (403 on Starter) |
+| `POST /dubbing` | verify object + enqueue (returns `projectId`, `jobId`) |
+| `POST /dubbing/stop/{jobId}` | cancel queued/active job |
+| `SSE /dubbing/status/{jobId}` | progress stream |
+| `GET /dubbing` / `GET /dubbing/{id}` / `DELETE /dubbing/{id}` | list / detail / delete |
+
+### 9.6 End-to-end UI checklist
+
+1. **Starter user** → `/dashboard/dubbing/new` shows the "Available on paid
+   plans" upgrade card; `POST /dubbing/sign-upload` returns 403.
+2. **Creator (or higher) user** → form is unlocked. Upload a short MP3/MP4,
+   name it, pick a language, hit **Dub**.
+3. Progress: upload % → `5` (queued) → `30` (translated) → `80` (cloned) →
+   `100`; success toast; Preview tab plays the audio.
+4. **Cancellation**: start a dub, click **Cancel Dubbing** while processing →
+   "Cancellation requested" → job ends with "Dubbing cancelled — no credits
+   were charged"; `dubbing_projects.status='failed'`,
+   `error_message='Dubbing cancelled by user'`; `profiles.credits` unchanged.
+5. Completed dub: credits deducted (`credits_consumed = ceil(sec)×15`), list
+   page shows the project, detail page previews original + dubbed, delete
+   removes the row and the GCS input object.
+6. Failure surfaces: stop the worker and submit → job sits queued (cancel
+   works); kill `MODAL_API_URL` → job fails at ~30% with the Modal error in
+   `error_message` and a failure toast.
+
+## 10. Out of scope for v1 (add when needed)
+
+- **Lip-sync for video.** v1.5 muxes dubbed audio over the original video track,
+  which drifts when translated speech is a different length than the source
+  (translations run longer/shorter). True sync needs segment-level time-alignment
+  or a lip-sync model (Wav2Lip / LatentSync). Ship audio-out first, then video-mux,
+  then sync.
+- **Multi-speaker diarization** — one reference voice per dub in v1. Per-speaker
+  cloning later.
+- **Consent capture** — Chatterbox watermarks output; an explicit "I have rights
+  to this voice" attestation on upload is a fast-follow for the deepfake/ToS story.
+- **Script/Story-Builder cross-links** (`script_id`) — column can exist, wiring later.
+- **Cancellation mid-clone** — the `train-ai` Redis-flag pattern is ready to bolt on.
+```

--- a/modal/.gitignore
+++ b/modal/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/modal/dubbing_app.py
+++ b/modal/dubbing_app.py
@@ -1,0 +1,129 @@
+# Creator AI — dubbing clone service (Modal, serverless GPU).
+#
+# Implements the contract the worker calls (packages/workers/.../dubbing.processor.ts):
+#   POST <MODAL_API_URL>  { text, reference_url, is_video, language }  ->  audio/wav bytes
+#
+# It fetches reference_url (a public GCS URL), extracts audio if is_video, clones the
+# speaker's voice from it and synthesizes `text` in `language` using Chatterbox
+# Multilingual (MIT license, 23 languages). Scales to zero between requests.
+#
+# Deploy:  modal deploy modal/dubbing_app.py
+# The deploy prints a dedicated URL for this endpoint, e.g.
+#   https://<you>--creator-ai-dubbing-dub.modal.run
+# Set MODAL_API_URL to EXACTLY that printed URL — Modal web endpoints each get their
+# own hostname, there is no "/dub" path on top of it. The worker POSTs to MODAL_API_URL
+# directly, with nothing appended.
+
+import subprocess
+import tempfile
+
+import modal
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("ffmpeg")
+    .pip_install("chatterbox-tts", "torch", "torchaudio", "requests", "fastapi[standard]")
+)
+
+app = modal.App("creator-ai-dubbing", image=image)
+
+# Chatterbox caps generation length; split long translations into sentence-ish chunks
+# and concatenate. ponytail: naive split on sentence enders — good enough for speech;
+# swap for a real segmenter if long inputs clip mid-word.
+def _chunk(text: str, max_chars: int = 300):
+    import re
+    parts, buf = [], ""
+    for sentence in re.split(r"(?<=[.!?。！？])\s+", text.strip()):
+        if len(buf) + len(sentence) + 1 <= max_chars:
+            buf = f"{buf} {sentence}".strip()
+        else:
+            if buf:
+                parts.append(buf)
+            buf = sentence
+    if buf:
+        parts.append(buf)
+    return parts or [text]
+
+
+@app.cls(gpu="L4", scaledown_window=120, timeout=900)
+class Dubber:
+    @modal.enter()
+    def load(self):
+        import torch
+        from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+
+        self.torch = torch
+        self.model = ChatterboxMultilingualTTS.from_pretrained(
+            device="cuda" if torch.cuda.is_available() else "cpu"
+        )
+
+    def _download(self, url: str) -> str:
+        import requests
+
+        resp = requests.get(url, timeout=120)
+        resp.raise_for_status()
+        src = tempfile.NamedTemporaryFile(suffix=".bin", delete=False)
+        src.write(resp.content)
+        src.flush()
+        return src.name
+
+    def _extract_reference(self, src_path: str) -> str:
+        # Normalize to 16k mono wav whether the source is audio or video — the clone
+        # model wants a clean reference sample.
+        wav_path = tempfile.NamedTemporaryFile(suffix=".wav", delete=False).name
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", src_path, "-vn", "-ac", "1", "-ar", "16000", wav_path],
+            check=True,
+            capture_output=True,
+        )
+        return wav_path
+
+    def _mux(self, video_path: str, audio_path: str) -> str:
+        # Replace the video's audio track with the dubbed audio. ponytail: -shortest
+        # trims to whichever stream is shorter — translated speech rarely matches the
+        # original length, so there is drift. Good enough for preview; true lip-sync
+        # (segment alignment / a sync model) is the upgrade path.
+        out_path = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False).name
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", video_path, "-i", audio_path,
+             "-map", "0:v:0", "-map", "1:a:0", "-c:v", "copy", "-c:a", "aac",
+             "-shortest", "-movflags", "+faststart", out_path],
+            check=True,
+            capture_output=True,
+        )
+        return out_path
+
+    @modal.fastapi_endpoint(method="POST", docs=True)
+    def dub(self, payload: dict):
+        from fastapi import Response
+        import torchaudio
+
+        text = (payload.get("text") or "").strip()
+        reference_url = payload.get("reference_url")
+        language = payload.get("language") or "en"
+        is_video = bool(payload.get("is_video"))
+        if not text or not reference_url:
+            return Response(content="text and reference_url are required", status_code=400)
+
+        # Download the source once; reuse it for both the voice reference and (video) mux.
+        src_path = self._download(reference_url)
+        ref = self._extract_reference(src_path)
+
+        segments = []
+        for chunk in _chunk(text):
+            wav = self.model.generate(chunk, language_id=language, audio_prompt_path=ref)
+            segments.append(wav)
+        audio = self.torch.cat(segments, dim=-1) if len(segments) > 1 else segments[0]
+
+        dubbed_wav = tempfile.NamedTemporaryFile(suffix=".wav", delete=False).name
+        torchaudio.save(dubbed_wav, audio.cpu(), self.model.sr)
+
+        # Video in → mux the dubbed audio over the original video and return an MP4.
+        if is_video:
+            out_mp4 = self._mux(src_path, dubbed_wav)
+            with open(out_mp4, "rb") as f:
+                return Response(content=f.read(), media_type="video/mp4")
+
+        # Audio in → return the dubbed WAV.
+        with open(dubbed_wav, "rb") as f:
+            return Response(content=f.read(), media_type="audio/wav")

--- a/packages/supabase/migrations/20260702010000_dubbing_jobs_align.sql
+++ b/packages/supabase/migrations/20260702010000_dubbing_jobs_align.sql
@@ -1,0 +1,68 @@
+-- Align dubbing_projects with the BullMQ job pipeline (see docs/dubbing-design.md).
+--
+-- The table was originally created for the inline (fire-and-forget) prototype.
+-- This migration adds the columns the queued worker needs and widens the status
+-- lifecycle. It is idempotent: safe to run whether or not the table/columns exist,
+-- and safe to re-run after a partial failure.
+--
+-- New status lifecycle: queued -> processing -> cloning -> completed | failed
+-- (legacy 'dubbing'/'dubbed' values are migrated in place below).
+
+-- 1. Columns the queued pipeline needs (no-op if already present).
+alter table public.dubbing_projects add column if not exists job_id          text;      -- BullMQ job id (SSE)
+alter table public.dubbing_projects add column if not exists input_gs_uri    text;      -- gs:// URI Vertex transcribes from
+alter table public.dubbing_projects add column if not exists input_url       text;      -- public GCS URL passed to the clone service
+alter table public.dubbing_projects add column if not exists duration_seconds numeric;  -- source length, drives credit cost
+alter table public.dubbing_projects add column if not exists error_message   text;      -- failure reason (the prototype never wrote this)
+
+-- 2. `status` was created as a native Postgres ENUM (dubbing_status) by the dashboard,
+--    not the text+CHECK pattern the rest of this schema uses (video_generation_jobs,
+--    subtitle_jobs, ...). You can't UPDATE a row to a value the enum doesn't contain,
+--    and ALTER TYPE ... ADD VALUE can't be used in the same transaction as the update
+--    — so convert the column to text first. Guarded: a no-op if already text (re-run safe).
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'dubbing_projects' and column_name = 'status'
+      and data_type = 'USER-DEFINED'
+  ) then
+    alter table public.dubbing_projects alter column status drop default;
+    alter table public.dubbing_projects alter column status type text using status::text;
+  end if;
+end $$;
+
+-- 3. Migrate any legacy status values from the prototype (now safe — plain text).
+update public.dubbing_projects set status = 'processing' where status = 'dubbing';
+update public.dubbing_projects set status = 'completed'  where status = 'dubbed';
+
+-- 4. Replace whatever CHECK constraint exists on status with the new lifecycle.
+--    Drop by discovery so an unknown dashboard-created constraint name is handled.
+do $$
+declare c record;
+begin
+  for c in
+    select con.conname
+    from pg_constraint con
+    join pg_class rel on rel.oid = con.conrelid
+    join pg_namespace nsp on nsp.oid = rel.relnamespace
+    where nsp.nspname = 'public'
+      and rel.relname = 'dubbing_projects'
+      and con.contype = 'c'
+  loop
+    execute format('alter table public.dubbing_projects drop constraint %I', c.conname);
+  end loop;
+end $$;
+
+alter table public.dubbing_projects
+  add constraint dubbing_projects_status_check
+  check (status in ('queued', 'processing', 'cloning', 'completed', 'failed'));
+
+alter table public.dubbing_projects alter column status set default 'queued';
+
+-- 5. The old enum type is now unreferenced (column converted to text in step 2) — drop it
+--    so it doesn't linger as dead schema. IF EXISTS: no-op if already dropped or never existed.
+drop type if exists public.dubbing_status;
+
+-- 6. Index for the SSE job lookup.
+create index if not exists idx_dubbing_projects_job_id on public.dubbing_projects using btree (job_id);

--- a/packages/validations/src/consts/credits.ts
+++ b/packages/validations/src/consts/credits.ts
@@ -5,6 +5,9 @@ export const SUBTITLE_CREDIT_MULTIPLIER = 2;
 export const IDEATION_CREDIT_MULTIPLIER = 1;
 export const STORY_BUILDER_CREDIT_MULTIPLIER = 1;
 export const TRAIN_AI_CREDIT_MULTIPLIER = 2;
+// Dubbing is billed per SECOND of source audio — GPU (clone) time scales with
+// length, so a flat cost loses money at scale. Tune via DUBBING_CREDIT_MULTIPLIER.
+export const DUBBING_CREDIT_MULTIPLIER = 15;
 
 export const FeatureType = {
   SCRIPT_GENERATION: 'script_generation',
@@ -47,9 +50,24 @@ export function calculateCreditsFromTokens(
   return Math.max(minimumCredits, baseCredits * multiplier);
 }
 
+/** @deprecated flat external-credit model — use calculateDubbingCreditsByDuration. */
 export function calculateDubbingCredits(params: ExternalCreditParams): number {
   const { externalCreditsUsed, multiplier = 10 } = params;
   return externalCreditsUsed * multiplier;
+}
+
+// Duration-based (mirrors calculateVideoGenerationCredits): cost = seconds ×
+// credits/sec, rounded up so a partial second still charges a full second.
+export function calculateDubbingCreditsByDuration(
+  durationSeconds: number,
+  multiplier = DUBBING_CREDIT_MULTIPLIER,
+): number {
+  return Math.max(multiplier, Math.ceil(durationSeconds) * multiplier);
+}
+
+// Precheck floor before enqueue: enough for one second at the given rate.
+export function getMinimumCreditsForDubbing(multiplier = DUBBING_CREDIT_MULTIPLIER): number {
+  return multiplier;
 }
 
 export function hasEnoughCredits(userCredits: number, requiredCredits: number): boolean {

--- a/packages/validations/src/consts/dubbing.check.ts
+++ b/packages/validations/src/consts/dubbing.check.ts
@@ -1,0 +1,75 @@
+/**
+ * Runnable self-check for the dubbing pure logic. No framework.
+ *   npx tsx packages/validations/src/consts/dubbing.check.ts
+ */
+import assert from 'node:assert';
+import { canDub, DUBBING_PLANS, DUBBING_CANCEL_PREFIX } from './dubbing';
+import {
+  calculateDubbingCreditsByDuration,
+  getMinimumCreditsForDubbing,
+  DUBBING_CREDIT_MULTIPLIER,
+} from './credits';
+import { SignDubUploadSchema, CreateDubSchema } from '../schema/dubbing.schema';
+
+// Plan gating: every paid plan, only Starter excluded; case-insensitive, null-safe.
+assert.equal(canDub('Creator'), true);
+assert.equal(canDub('pro'), true);
+assert.equal(canDub('Business'), true);
+assert.equal(canDub('SCALE'), true);
+assert.equal(canDub('Starter'), false);
+assert.equal(canDub(null), false);
+assert.equal(canDub(undefined), false);
+assert.equal(canDub(''), false);
+assert.deepEqual([...DUBBING_PLANS], ['creator', 'pro', 'business', 'scale']);
+
+// Duration-based credits: cost = ceil(seconds) × multiplier, floored at one second.
+assert.equal(calculateDubbingCreditsByDuration(60, 15), 900);
+assert.equal(calculateDubbingCreditsByDuration(59.2, 15), 900); // rounds up
+assert.equal(calculateDubbingCreditsByDuration(0, 15), 15); // floor: never free
+assert.equal(calculateDubbingCreditsByDuration(1, 15), 15);
+assert.equal(getMinimumCreditsForDubbing(15), 15);
+assert.equal(getMinimumCreditsForDubbing(), DUBBING_CREDIT_MULTIPLIER);
+
+// Sign-upload schema: audio/video only, positive size and duration required.
+assert.equal(
+  SignDubUploadSchema.safeParse({
+    filename: 'a.mp3', contentType: 'audio/mpeg', fileSize: 1000, isVideo: false, durationSeconds: 12.5,
+  }).success,
+  true,
+);
+assert.equal(
+  SignDubUploadSchema.safeParse({
+    filename: 'a.pdf', contentType: 'application/pdf', fileSize: 1000, isVideo: false, durationSeconds: 10,
+  }).success,
+  false, // not audio/* or video/*
+);
+assert.equal(
+  SignDubUploadSchema.safeParse({
+    filename: 'a.mp3', contentType: 'audio/mpeg', fileSize: 1000, isVideo: false, durationSeconds: 0,
+  }).success,
+  false, // duration must be positive
+);
+
+// Create schema: objectName-based (no raw client URL); numbers coerce, booleans don't.
+const created = CreateDubSchema.parse({
+  objectName: 'user-1/dubbing/123_a.mp3',
+  targetLanguage: 'es',
+  isVideo: false,
+  mediaName: 'My clip',
+  durationSeconds: '42',
+});
+assert.equal(created.isVideo, false);
+assert.equal(created.durationSeconds, 42);
+// The string "false" must be rejected, not silently coerced to true.
+assert.equal(
+  CreateDubSchema.safeParse({
+    objectName: 'user-1/dubbing/123_a.mp3', targetLanguage: 'es', isVideo: 'false', mediaName: 'x', durationSeconds: 5,
+  }).success,
+  false,
+);
+assert.equal(CreateDubSchema.safeParse({ targetLanguage: 'es', isVideo: false, mediaName: 'x', durationSeconds: 5 }).success, false); // objectName required
+
+// Cancel prefix is stable — the API sets it, the worker polls it.
+assert.equal(DUBBING_CANCEL_PREFIX, 'dubbing:cancel:');
+
+console.log('dubbing self-check OK');

--- a/packages/validations/src/consts/dubbing.ts
+++ b/packages/validations/src/consts/dubbing.ts
@@ -1,4 +1,18 @@
 
+// Dubbing is a paid feature — every paid plan gets it; only Starter (free) is
+// excluded. Gate by plan NAME: there is no tier column; the active plan is the
+// most-recent active `subscriptions` row joined to `plans` (mirror canGenerateVideo).
+export const DUBBING_PLANS = ['creator', 'pro', 'business', 'scale'] as const;
+
+export function canDub(planName?: string | null): boolean {
+  if (!planName) return false;
+  return DUBBING_PLANS.includes(planName.toLowerCase() as (typeof DUBBING_PLANS)[number]);
+}
+
+// Redis key prefix for mid-run cancellation (train-ai pattern). The API sets the
+// flag; the worker checks it between pipeline stages and aborts.
+export const DUBBING_CANCEL_PREFIX = 'dubbing:cancel:';
+
 export const supportedLanguages = [
   { value: 'en', label: 'English' },
   { value: 'zh', label: 'Chinese (Mandarin)' },

--- a/packages/validations/src/schema/dubbing.schema.ts
+++ b/packages/validations/src/schema/dubbing.schema.ts
@@ -1,10 +1,26 @@
 import { z } from 'zod';
 
+// Step 1: ask the API for a signed URL to PUT the source media straight to GCS.
+// The API plan-gates and enforces size before issuing the URL.
+export const SignDubUploadSchema = z.object({
+  filename: z.string().min(1).max(200),
+  contentType: z
+    .string()
+    .refine((t) => /^(audio|video)\//.test(t), { message: 'Only audio or video files are supported' }),
+  fileSize: z.coerce.number().int().positive(),
+  // Real boolean only — z.coerce.boolean() would turn the string "false" into true.
+  isVideo: z.boolean(),
+  durationSeconds: z.coerce.number().positive({ message: 'Duration is required' }),
+});
+
+// Step 2: after the browser uploaded to GCS, create the dubbing job from the
+// verified object. No raw URL from the client — the API derives it from objectName.
 export const CreateDubSchema = z.object({
-  mediaUrl: z.string().url({ message: 'Invalid media URL' }),
+  objectName: z.string().min(1, { message: 'objectName is required' }),
   targetLanguage: z.string().min(1, { message: 'Target language is required' }),
   isVideo: z.boolean(),
   mediaName: z.string().min(1, { message: 'Media name is required' }).max(100),
+  durationSeconds: z.coerce.number().positive({ message: 'Duration is required' }),
 });
 
 // Output/response schema
@@ -12,7 +28,7 @@ export const DubResponseSchema = z.object({
   projectId: z.string(),
   dubbedUrl: z.string().optional(),
   originalMediaUrl: z.string().optional(),
-  status: z.enum(['dubbing', 'dubbed']),
+  status: z.enum(['queued', 'processing', 'cloning', 'completed', 'failed']),
   creditsConsumed: z.number().optional(),
   isVideo: z.boolean(),
   createdAt: z.string(),
@@ -20,5 +36,6 @@ export const DubResponseSchema = z.object({
   mediaName: z.string().optional(),
 });
 
+export type SignDubUploadInput = z.infer<typeof SignDubUploadSchema>;
 export type CreateDubInput = z.infer<typeof CreateDubSchema>;
 export type DubResponse = z.infer<typeof DubResponseSchema>;

--- a/packages/workers/src/processor/dubbing.processor.ts
+++ b/packages/workers/src/processor/dubbing.processor.ts
@@ -1,0 +1,229 @@
+import { Processor, WorkerHost, InjectQueue } from '@nestjs/bullmq';
+import { Job, Queue } from 'bullmq';
+import { Logger } from '@nestjs/common';
+import { createSupabaseClient, getSupabaseServiceEnv, SupabaseClient } from '@repo/supabase';
+import {
+  calculateDubbingCreditsByDuration,
+  DUBBING_CREDIT_MULTIPLIER,
+  DUBBING_CANCEL_PREFIX,
+  supportedLanguages,
+} from '@repo/validation';
+import { GoogleGenAI } from '@google/genai';
+import { getGenAI, GEMINI_TEXT_MODEL } from './utils/genai';
+
+// The clone step (Modal GPU) can run for a few minutes — cap the wait so a hung
+// request fails the job instead of pinning a worker slot forever.
+const MODAL_TIMEOUT_MS = 10 * 60 * 1000;
+
+class DubbingCancelledError extends Error {
+  constructor() {
+    super('Dubbing cancelled by user');
+    this.name = 'DubbingCancelledError';
+  }
+}
+
+interface DubJobData {
+  userId: string;
+  projectId: string;
+  bullJobId: string;
+  inputGsUri: string;   // gs:// — Vertex transcribes/translates directly from this
+  inputUrl: string;     // public GCS URL — the clone service fetches the reference from this
+  mimeType: string;
+  isVideo: boolean;
+  targetLanguage: string;
+  durationSeconds: number;
+}
+
+@Processor('dubbing', { concurrency: 2 })
+export class DubbingProcessor extends WorkerHost {
+  private readonly logger = new Logger(DubbingProcessor.name);
+  private readonly supabase: SupabaseClient;
+  private readonly genAI: GoogleGenAI;
+
+  constructor(@InjectQueue('dubbing') private readonly queue: Queue) {
+    super();
+    const { url, key } = getSupabaseServiceEnv();
+    this.supabase = createSupabaseClient(url, key);
+    this.genAI = getGenAI();
+  }
+
+  /** Cancellation flag set by POST /dubbing/stop/:jobId — checked between stages. */
+  private async throwIfCancelled(jobId: string): Promise<void> {
+    const client = await this.queue.client;
+    const cancelled = await client.get(`${DUBBING_CANCEL_PREFIX}${jobId}`);
+    if (cancelled) {
+      await client.del(`${DUBBING_CANCEL_PREFIX}${jobId}`);
+      throw new DubbingCancelledError();
+    }
+  }
+
+  async process(job: Job<DubJobData>): Promise<{ dubbedUrl: string }> {
+    const { userId, projectId, inputGsUri, inputUrl, mimeType, isVideo, targetLanguage, durationSeconds } = job.data;
+
+    await job.updateProgress(0);
+    await job.log('Starting dubbing...');
+
+    try {
+      const modalUrl = process.env.MODAL_API_URL;
+      if (!modalUrl) throw new Error('MODAL_API_URL is not configured');
+
+      await this.throwIfCancelled(job.id!);
+      await this.updateJob(projectId, { status: 'processing' });
+      await job.updateProgress(5);
+
+      // targetLanguage is an ISO code (e.g. 'es'); Gemini wants the full name, the
+      // clone model wants the code as its language_id.
+      const languageLabel = supportedLanguages.find((l) => l.value === targetLanguage)?.label ?? targetLanguage;
+
+      // 1. Transcribe + translate. Vertex reads the media straight from gs:// —
+      //    no inline bytes, no Files API, no 50MB ceiling (same as subtitles).
+      await job.log(`Transcribing and translating to ${languageLabel}...`);
+      const translatedText = await this.transcribeAndTranslate(inputGsUri, mimeType, languageLabel);
+      await job.updateProgress(30);
+
+      // 2. Clone the voice + synthesize the translation (Modal GPU). For a video
+      //    input, Modal also muxes the dubbed audio back over the original video and
+      //    returns an MP4; for audio input it returns a WAV.
+      await this.throwIfCancelled(job.id!);
+      await this.updateJob(projectId, { status: 'cloning' });
+      await job.log(isVideo ? 'Cloning voice and rebuilding video...' : 'Cloning voice and generating dubbed audio...');
+      const dubbedMedia = await this.callModalDub(modalUrl, translatedText, inputUrl, isVideo, targetLanguage);
+      await job.updateProgress(80);
+
+      // 3. Store the result — MP4 for video dubs, WAV for audio (Supabase Storage).
+      // Last cancellation window — after this we charge credits and persist.
+      await this.throwIfCancelled(job.id!);
+      const filePath = isVideo ? `dubbed/${projectId}.mp4` : `dubbed/${projectId}.wav`;
+      const outputContentType = isVideo ? 'video/mp4' : 'audio/wav';
+      const { error: uploadError } = await this.supabase.storage
+        .from('dubbing_media')
+        .upload(filePath, dubbedMedia, { contentType: outputContentType, upsert: true });
+      if (uploadError) throw new Error(`Storage upload failed: ${uploadError.message}`);
+
+      const { data: urlData } = this.supabase.storage.from('dubbing_media').getPublicUrl(filePath);
+      await job.updateProgress(90);
+
+      // 4. Deduct duration-based credits — only after a successful clone.
+      const multiplier = this.getEnvNumber('DUBBING_CREDIT_MULTIPLIER', DUBBING_CREDIT_MULTIPLIER);
+      const creditsConsumed = calculateDubbingCreditsByDuration(durationSeconds, multiplier);
+
+      const { error: creditError } = await this.supabase.rpc('update_user_credits', {
+        user_uuid: userId,
+        credit_change: -creditsConsumed,
+      });
+      if (creditError) {
+        this.logger.error(`Credit deduction failed for user ${userId}: ${creditError.message}`);
+        await this.updateJob(projectId, { status: 'failed', error_message: 'Insufficient credits' });
+        throw new Error('Insufficient credits. Please upgrade your plan.');
+      }
+
+      await this.updateJob(projectId, {
+        status: 'completed',
+        dubbed_url: urlData.publicUrl,
+        credits_consumed: creditsConsumed,
+      });
+      await job.updateProgress(100);
+      await job.log(`Done! ${creditsConsumed} credits deducted.`);
+
+      return { dubbedUrl: urlData.publicUrl };
+    } catch (error: any) {
+      const cancelled = error instanceof DubbingCancelledError;
+      await job.log(cancelled ? 'Cancelled by user.' : `Fatal error: ${error.message}`);
+      if (!cancelled) {
+        this.logger.error(`Job ${job.id} failed: ${error.message}`, error.stack);
+      }
+      try {
+        await this.updateJob(projectId, { status: 'failed', error_message: error.message?.slice(0, 5000) });
+      } catch (updateError: any) {
+        this.logger.error(
+          `Job ${job.id}: failed to persist failed status for dub ${projectId}: ${updateError?.message}`,
+          updateError?.stack,
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async transcribeAndTranslate(gsUri: string, mimeType: string, targetLanguage: string): Promise<string> {
+    const result = await this.genAI.models.generateContent({
+      model: GEMINI_TEXT_MODEL,
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              text: `Transcribe the spoken audio from this file, then translate the full transcript into ${targetLanguage}. Return ONLY the translated text as a single continuous paragraph. No timestamps, no formatting, no labels — just the translated text.`,
+            },
+            { fileData: { fileUri: gsUri, mimeType } },
+          ],
+        },
+      ],
+    });
+
+    const text = result.text?.trim();
+    if (!text) throw new Error('Empty transcription/translation result from Gemini');
+    return text;
+  }
+
+  /**
+   * Modal contract: JSON { text, reference_url, is_video, language } → dubbed media.
+   * MODAL_API_URL is the exact URL `modal deploy` printed for the /dub endpoint — Modal
+   * gives each web endpoint its own dedicated hostname, there is no path routing on top
+   * of it, so we POST to modalUrl directly (no path appended). Modal fetches reference_url
+   * (public GCS URL), extracts audio if is_video, clones the voice and synthesizes `text`
+   * in `language`. When is_video it muxes the dubbed audio over the original video and
+   * returns an MP4 (video/mp4); otherwise a WAV (audio/wav). Also accepts { audio_base64 }.
+   */
+  private async callModalDub(
+    modalUrl: string,
+    text: string,
+    referenceUrl: string,
+    isVideo: boolean,
+    language: string,
+  ): Promise<Buffer> {
+    const response = await fetch(modalUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, reference_url: referenceUrl, is_video: isVideo, language }),
+      signal: AbortSignal.timeout(MODAL_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => 'Unknown error');
+      throw new Error(`Modal API error ${response.status}: ${errBody.slice(0, 500)}`);
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('audio') || contentType.includes('video') || contentType.includes('octet-stream')) {
+      return Buffer.from(await response.arrayBuffer());
+    }
+
+    const jsonBody = (await response.json()) as Record<string, unknown>;
+    for (const key of ['audio_base64', 'audio', 'data']) {
+      if (typeof jsonBody[key] === 'string') return Buffer.from(jsonBody[key] as string, 'base64');
+    }
+    throw new Error('Unexpected response format from Modal dubbing API');
+  }
+
+  private async updateJob(projectId: string, fields: Record<string, any>) {
+    const { data, error } = await this.supabase
+      .from('dubbing_projects')
+      .update({ ...fields })
+      .eq('project_id', projectId)
+      .select('project_id')
+      .single();
+
+    if (error || !data) {
+      this.logger.error(
+        `Failed to update dubbing_projects project_id=${projectId}. fields=${Object.keys(fields).join(', ')} error=${error?.message ?? 'no rows updated (RLS or missing row)'}`,
+      );
+      throw new Error(`dubbing_projects update failed: ${error?.message ?? 'row not found or RLS blocked'}`);
+    }
+  }
+
+  private getEnvNumber(key: string, fallback: number): number {
+    const raw = process.env[key];
+    const parsed = raw ? Number(raw) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+}

--- a/packages/workers/src/worker.module.ts
+++ b/packages/workers/src/worker.module.ts
@@ -9,6 +9,7 @@ import { ThumbnailProcessor } from './processor/thumbnail.processor';
 import { StoryBuilderProcessor } from './processor/story-builder.processor';
 import { IdeationProcessor } from './processor/ideation.processor';
 import { ScriptProcessor } from './processor/script.processor';
+import { DubbingProcessor } from './processor/dubbing.processor';
 
 @Module({
   controllers: [HealthController],
@@ -37,8 +38,9 @@ import { ScriptProcessor } from './processor/script.processor';
       { name: 'story-builder' },
       { name: 'ideation' },
       { name: 'script' },
+      { name: 'dubbing' },
     ),
   ],
-  providers: [TrainAiProcessor, ThumbnailProcessor, StoryBuilderProcessor, IdeationProcessor, ScriptProcessor],
+  providers: [TrainAiProcessor, ThumbnailProcessor, StoryBuilderProcessor, IdeationProcessor, ScriptProcessor, DubbingProcessor],
 })
 export class WorkerModule {}


### PR DESCRIPTION
## Audio Dubbing

Voice-preserving dubbing: upload audio/video → transcribe + translate (Gemini on Vertex) → clone the speaker's voice → re-voice in the target language, and (for video) mux the dubbed audio back over the footage. Gated to paid plans (Creator, Pro, Business, Scale — Starter excluded).

Replaces the fire-and-forget prototype with a durable **BullMQ queued pipeline**, adds plan gating, GCS-backed uploads, duration-based credits, mid-run cancellation, and in-place regeneration.

### Dubbing commits
- `feat(validation)` — plan gate (`canDub`), duration credits, signed-upload + objectName schemas, self-check
- `feat(api)` — GCS dubbing bucket helper (`GCS_DUBBING_BUCKET`, optional bucket arg)
- `feat(workers)` — queued `dubbing` processor: Gemini translate → Modal clone → (video) mux → Supabase upload → credits; cancel between stages
- `feat(api)` — service/controller/module: plan gate, signed upload, enqueue, access check, stop, regenerate; Swagger; unit tests
- `feat(web)` — `useDubbing` hook + api client
- `feat(web)` — components: custom media player, animated mic hero, how-it-works
- `feat(web)` — new/detail/list pages, dashboard quick-action + sidebar nav
- `feat(modal)` — Chatterbox Multilingual `/dub` service with video mux
- `docs` — design doc + env entries
- migration — `dubbing_projects` align (adds `error_message`, converts `status` enum→text)

### Also included (dubbing builds on these unmerged commits)
- 6 `feat(subtitle)` commits — GCS-backed direct uploads + plan limits (dubbing reuses this upload flow)
- 3 chore/refactor commits

### Deliberately excluded
The in-progress **video generation** feature is left out (uncommitted in the working tree) — this PR is dubbing-only.

## Production setup required
1. Create `GCS_DUBBING_BUCKET` — public-read, CORS for the web origin, Vertex/worker SA `roles/storage.objectAdmin`
2. `modal deploy modal/dubbing_app.py` → set `MODAL_API_URL` to the exact printed endpoint URL
3. Env on **API + worker**: `GCS_DUBBING_BUCKET`, `MODAL_API_URL`, optional `DUBBING_CREDIT_MULTIPLIER`
4. Ensure a **public** Supabase Storage `dubbing_media` bucket
5. Run migration `20260702010000_dubbing_jobs_align.sql`
6. Deploy the worker with the new `dubbing` queue
7. Calibrate `DUBBING_CREDIT_MULTIPLIER` (credits/sec) to real Modal GPU cost

## Testing
- `npx tsx packages/validations/src/consts/dubbing.check.ts` (pure-logic self-check)
- `cd apps/api && npx jest src/dubbing` (service tests: gate, upload, enqueue, cancel)
- Full local E2E in `docs/dubbing-design.md` §9
