### PR TITLE
fix(docker): build workers from Dockerfile.worker; drop stale yt-dlp …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,17 +16,12 @@ services:
   workers:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.worker
     container_name: workers
     env_file:
       - packages/workers/.env
-
-  yt-dlp:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: yt-dlp
-   
+    depends_on:
+      - redis
 
 volumes:
   redis_data:


### PR DESCRIPTION
The root Dockerfile was renamed to Dockerfile.worker in 54fb5d6 (Railway split) but docker-compose.yml still referenced the old name, so 'docker compose up' failed with 'open Dockerfile: no such file or directory'. yt-dlp + ffmpeg are already installed in Dockerfile.worker, so the separate yt-dlp service was redundant and is removed.