### PR TITLE
feat: AI audio dubbing (GCS-backed, streamed off the worker)

### DIFF
--- a/apps/api/src/dubbing/dubbing.service.ts
+++ b/apps/api/src/dubbing/dubbing.service.ts
@@ -32,6 +32,20 @@ import {
 // Dubbing input is usually a short clip, but a video can be large — cap generously.
 const MAX_DUB_UPLOAD_BYTES = 500 * 1024 * 1024; // 500MB
 
+// The output PUT URL is minted here (at enqueue) but used later by Modal, which only
+// runs after the job leaves the queue and the clone finishes (minutes). Give it a wide
+// window so a backlogged queue doesn't expire the URL before Modal uploads.
+// ponytail: 2h covers the concurrency-2 queue; if backlogs ever exceed it, mint the URL
+// in the worker right before the Modal call instead (needs GCS signing in the worker).
+const OUTPUT_URL_TTL_MS = 2 * 60 * 60 * 1000; // 2h
+
+/** Deterministic output object + content type, derivable from projectId alone (for cleanup). */
+function dubOutput(projectId: string, isVideo: boolean): { objectName: string; contentType: string } {
+  return isVideo
+    ? { objectName: `dubbed/${projectId}.mp4`, contentType: 'video/mp4' }
+    : { objectName: `dubbed/${projectId}.wav`, contentType: 'audio/wav' };
+}
+
 @Injectable()
 export class DubbingService {
   private readonly logger = new Logger(DubbingService.name);
@@ -167,6 +181,8 @@ export class DubbingService {
       throw new InternalServerErrorException('Failed to create dubbing project');
     }
 
+    const output = await this.signOutputUpload(projectId, isVideo);
+
     const bullJobId = `dubbing-${userId}-${Date.now()}`;
     await this.queue.add(
       'dubbing',
@@ -180,6 +196,7 @@ export class DubbingService {
         isVideo,
         targetLanguage,
         durationSeconds,
+        ...output,
       },
       { jobId: bullJobId },
     );
@@ -187,6 +204,26 @@ export class DubbingService {
     await this.supabase.from('dubbing_projects').update({ job_id: bullJobId }).eq('project_id', projectId);
 
     return { projectId, jobId: bullJobId };
+  }
+
+  /**
+   * Mint the destination for the dubbed file: a long-lived signed PUT URL Modal uploads
+   * to directly (the worker never handles the bytes), plus the public URL we'll record.
+   */
+  private async signOutputUpload(projectId: string, isVideo: boolean) {
+    const { objectName, contentType } = dubOutput(projectId, isVideo);
+    const outputPutUrl = await getSignedUploadUrl(
+      this.configService,
+      objectName,
+      contentType,
+      this.bucket,
+      OUTPUT_URL_TTL_MS,
+    );
+    return {
+      outputPutUrl,
+      outputContentType: contentType,
+      outputPublicUrl: gcsPublicUrl(this.configService, objectName, this.bucket),
+    };
   }
 
   /**
@@ -237,6 +274,8 @@ export class DubbingService {
       .eq('project_id', projectId)
       .eq('user_id', userId);
 
+    const output = await this.signOutputUpload(projectId, row.is_video);
+
     const bullJobId = `dubbing-${userId}-${Date.now()}`;
     await this.queue.add(
       'dubbing',
@@ -250,6 +289,7 @@ export class DubbingService {
         isVideo: row.is_video,
         targetLanguage: row.target_language,
         durationSeconds: Number(row.duration_seconds),
+        ...output,
       },
       { jobId: bullJobId },
     );
@@ -334,19 +374,22 @@ export class DubbingService {
       .delete()
       .eq('user_id', userId)
       .eq('project_id', projectId)
-      .select('input_gs_uri')
+      .select('input_gs_uri, is_video')
       .single();
 
     if (error) throw new BadRequestException('Dub not found or access denied');
 
-    // Clean up the source object in GCS (output WAV is left to Supabase lifecycle).
-    if (data?.input_gs_uri) {
-      const objectName = String(data.input_gs_uri).split('/').slice(3).join('/');
-      if (objectName) {
-        await deleteGcsObject(this.configService, objectName, this.bucket).catch((e) =>
-          this.logger.error(`Failed to delete GCS object ${objectName}`, e),
-        );
-      }
+    // Clean up both GCS objects: the source (input_gs_uri) and the dubbed output
+    // (deterministic name from projectId + is_video).
+    const objectNames = [
+      data?.input_gs_uri ? String(data.input_gs_uri).split('/').slice(3).join('/') : null,
+      dubOutput(projectId, Boolean(data?.is_video)).objectName,
+    ].filter((n): n is string => Boolean(n));
+
+    for (const objectName of objectNames) {
+      await deleteGcsObject(this.configService, objectName, this.bucket).catch((e) =>
+        this.logger.error(`Failed to delete GCS object ${objectName}`, e),
+      );
     }
   }
 }

--- a/apps/api/src/utils/gcs.ts
+++ b/apps/api/src/utils/gcs.ts
@@ -34,6 +34,14 @@ function getBucketName(configService: ConfigService): string {
   return bucket;
 }
 
+function getVideoBucketName(configService: ConfigService): string {
+  const bucket = configService.get<string>('GCS_VIDEO_BUCKET');
+  if (!bucket) {
+    throw new Error('GCS_VIDEO_BUCKET is not configured');
+  }
+  return bucket;
+}
+
 /** Dubbing keeps its own bucket so retention/cleanup can diverge from subtitles. */
 export function getDubbingBucketName(configService: ConfigService): string {
   const bucket = configService.get<string>('GCS_DUBBING_BUCKET');
@@ -41,6 +49,28 @@ export function getDubbingBucketName(configService: ConfigService): string {
     throw new Error('GCS_DUBBING_BUCKET is not configured');
   }
   return bucket;
+}
+
+/** gs:// prefix Veo writes generated video(s) into. Trailing slash: it's a folder. */
+export function videoGcsOutputPrefix(configService: ConfigService, objectPrefix: string): string {
+  return `gs://${getVideoBucketName(configService)}/${objectPrefix}`;
+}
+
+/** gs://bucket/object → https public URL (video bucket is public-read, like subtitles). */
+export function gcsUriToPublicUrl(gsUri: string): string {
+  // gs://bucket/a/b.mp4 → https://storage.googleapis.com/bucket/a/b.mp4
+  return gsUri.replace(/^gs:\/\//, 'https://storage.googleapis.com/');
+}
+
+/** Delete an object from the video bucket by its gs:// URI (for job cleanup). */
+export async function deleteVideoGcsUri(configService: ConfigService, gsUri: string): Promise<void> {
+  const bucket = getVideoBucketName(configService);
+  const prefix = `gs://${bucket}/`;
+  if (!gsUri.startsWith(prefix)) return;
+  const objectName = gsUri.slice(prefix.length);
+  if (!objectName) return;
+  const storage = await getStorage(configService);
+  await storage.bucket(bucket).file(objectName).delete({ ignoreNotFound: true });
 }
 
 // The helpers below default to the subtitle bucket; pass `bucket` (e.g.
@@ -64,6 +94,7 @@ export async function getSignedUploadUrl(
   objectName: string,
   contentType: string,
   bucket?: string,
+  expiresMs: number = 15 * 60 * 1000,
 ): Promise<string> {
   const storage = await getStorage(configService);
   const [url] = await storage
@@ -72,7 +103,7 @@ export async function getSignedUploadUrl(
     .getSignedUrl({
       version: 'v4',
       action: 'write',
-      expires: Date.now() + 15 * 60 * 1000,
+      expires: Date.now() + expiresMs,
       contentType,
     });
   return url;

--- a/apps/web/app/blog/[id]/page.tsx
+++ b/apps/web/app/blog/[id]/page.tsx
@@ -422,6 +422,12 @@ export default function BlogDetailPage() {
               >
                 Get Started Free
               </Link>
+              <p className="text-purple-100/90 text-sm mt-5">
+                Questions? Reach us at{" "}
+                <a href="mailto:support@tryscriptai.com" className="underline hover:text-white">
+                  support@tryscriptai.com
+                </a>
+              </p>
             </motion.div>
           </div>
         </section>

--- a/apps/web/app/contact-us/page.tsx
+++ b/apps/web/app/contact-us/page.tsx
@@ -97,6 +97,12 @@ export default function ContactPage() {
                 <CardTitle className="text-2xl text-center text-slate-900 dark:text-white">
                   Send Us a Message
                 </CardTitle>
+                <p className="text-sm text-center text-slate-600 dark:text-slate-300">
+                  Or email us directly at{" "}
+                  <a href="mailto:support@tryscriptai.com" className="text-purple-600 dark:text-purple-400 hover:underline">
+                    support@tryscriptai.com
+                  </a>
+                </p>
               </CardHeader>
 
               <CardContent>

--- a/apps/web/components/footer.tsx
+++ b/apps/web/components/footer.tsx
@@ -92,6 +92,12 @@ const Footer = () => {
               <p className="text-sm text-slate-600 dark:text-slate-400 max-w-xs">
                 Personalized AI assistant for content creators. Empowering creators worldwide.
               </p>
+              <a
+                href="mailto:support@tryscriptai.com"
+                className="block text-sm text-slate-600 dark:text-slate-400 hover:text-purple-500 dark:hover:text-purple-400 transition-colors"
+              >
+                support@tryscriptai.com
+              </a>
               <FloatingDock
                 desktopClassName="bg-transparent"
                 items={socialLinks.map((item) => ({

--- a/apps/web/components/landingPage/FAQSection.tsx
+++ b/apps/web/components/landingPage/FAQSection.tsx
@@ -79,7 +79,11 @@ export default function FAQSection() {
             Frequently Asked Questions
           </h2>
           <p className="max-w-[700px] text-slate-600 dark:text-slate-400 md:text-lg">
-            Got questions? We've got answers.
+            Got questions? We've got answers. Can't find yours? Email us at{" "}
+            <a href="mailto:support@tryscriptai.com" className="text-purple-600 dark:text-purple-400 hover:underline">
+              support@tryscriptai.com
+            </a>
+            .
           </p>
         </motion.div>
 

--- a/docs/dubbing-design.md
+++ b/docs/dubbing-design.md
@@ -15,8 +15,8 @@ only Starter (free) is excluded.
 ## 0. What already exists (and why it must change)
 
 There is a **working prototype** in `apps/api/src/dubbing/` (`dubbing.service.ts`,
-`dubbing.controller.ts`, `dubbing.module.ts`) plus a `dubbing_projects` table and
-a `dubbing_media` Supabase Storage bucket. It already does: Gemini
+`dubbing.controller.ts`, `dubbing.module.ts`) plus a `dubbing_projects` table. It
+already does: Gemini
 transcribe+translate, ffmpeg audio extraction, a call to a Modal `/dub`
 endpoint (VoxCPM), and credit deduction.
 
@@ -44,7 +44,7 @@ closes:
 | SSE progress | `createJobSSE` (`common/sse`) | Worker `job.updateProgress()` → browser. Replaces the DB-poll SSE. |
 | Credits | `update_user_credits` RPC + `calculateDubbingCredits` | Change to duration-based (§5). |
 | Plan gating | `getActivePlanName` in `VideoGenerationService` | Same `subscriptions → plans(name)` query; allow Pro/Business/Scale. |
-| Storage | `dubbing_media` Supabase bucket (output), GCS (input) | Input on GCS (Vertex needs `gs://`); output stays Supabase (small WAV/MP4). |
+| Storage | `GCS_DUBBING_BUCKET` (input + output) | Both on GCS. Input needs `gs://` for Vertex; output goes there too — Supabase's 50MB free-tier cap rejects dubbed MP4s. Modal PUTs the output straight to GCS so the worker never holds the bytes. |
 
 No new dependencies. `@nestjs/bullmq`, `@google/genai`, `@google-cloud/storage`,
 `fluent-ffmpeg` are all already installed and used.
@@ -70,11 +70,11 @@ Browser opens SSE  GET /dubbing/status/:jobId   (createJobSSE)
 Worker: DubbingProcessor.process()          [packages/workers]
   │   1. status='processing'  (progress 5)
   │   2. Gemini (Vertex, gs:// fileData): transcribe + translate → target text   (progress 30)
-  │   3. download media from GCS → ffmpeg extract clean reference WAV            (progress 45)
-  │   4. status='cloning'; POST Modal /dub { text, reference } → dubbed WAV      (progress 80)
-  │   5. (if isVideo) ffmpeg mux dubbed audio over original video → MP4          (progress 90)
-  │   6. upload result → dubbing_media (Supabase); deduct duration-based credits
-  │   7. status='completed', dubbed_url persisted                               (progress 100)
+  │   3. status='cloning'; POST Modal { text, reference_url, output_put_url }    (progress 80)
+  │        Modal clones + synthesizes, (if isVideo) muxes over the original,
+  │        and PUTs the result straight to GCS via the signed URL (worker holds no bytes)
+  │   4. deduct duration-based credits; dubbed_url = the GCS public URL
+  │   5. status='completed', dubbed_url persisted                               (progress 100)
   ▼
 SSE emits completed → browser plays the dubbed media
 ```
@@ -162,9 +162,11 @@ upgrade card to Starter users.
   `gs://` URI; Modal fetches the public URL as the voice reference. The shared
   `gcs.ts` helpers take an optional `bucket` argument, so no code duplication.
   See §9.1 for the bucket setup guide.
-- **Output** → keep the existing `dubbing_media` Supabase Storage bucket. Output
-  is a small WAV; Supabase public URL is already wired. No reason to move it.
-- Delete cleans up the GCS input object on `DELETE /dubbing/:id`.
+- **Output** → same **`GCS_DUBBING_BUCKET`**. The API mints a long-lived signed PUT
+  URL at enqueue; Modal uploads the dubbed file straight to it, so the worker never
+  holds the bytes (a dubbed MP4 can be hundreds of MB). Supabase Storage was dropped —
+  its 50MB free-tier cap rejects dubbed video.
+- Delete cleans up both GCS objects (input + output) on `DELETE /dubbing/:id`.
 
 ## 5b. Cancellation (train-ai pattern)
 
@@ -279,8 +281,8 @@ gcloud storage buckets update gs://creator-ai-dubbing --cors-file=cors.json
 > `iam.serviceAccounts.signBlob` on an attached SA — same requirement as the
 > subtitle uploader.
 
-Also ensure the **Supabase** Storage bucket `dubbing_media` exists and is public
-(worker uploads the dubbed WAV there).
+The dubbed output lands in the same `GCS_DUBBING_BUCKET` (Modal PUTs it there via the
+signed URL) — no separate output bucket to provision.
 
 ### 9.2 One-time setup — Modal + env + DB
 

--- a/modal/dubbing_app.py
+++ b/modal/dubbing_app.py
@@ -1,11 +1,18 @@
 # Creator AI — dubbing clone service (Modal, serverless GPU).
 #
 # Implements the contract the worker calls (packages/workers/.../dubbing.processor.ts):
-#   POST <MODAL_API_URL>  { text, reference_url, is_video, language }  ->  audio/wav bytes
+#   POST <MODAL_API_URL>
+#     { text, reference_url, is_video, language, output_put_url, output_content_type }
+#   -> streams the dubbed file straight to GCS via output_put_url, returns { "ok": true }
 #
 # It fetches reference_url (a public GCS URL), extracts audio if is_video, clones the
 # speaker's voice from it and synthesizes `text` in `language` using Chatterbox
-# Multilingual (MIT license, 23 languages). Scales to zero between requests.
+# Multilingual (MIT license, 23 languages). The result is uploaded directly to GCS with
+# the pre-signed PUT URL the API minted, so the dubbed media (a video can be hundreds of
+# MB) never round-trips through the Node worker. Scales to zero between requests.
+#
+# Back-compat: if output_put_url is omitted, it falls back to returning the raw bytes
+# (handy for `modal run` / curl testing).
 #
 # Deploy:  modal deploy modal/dubbing_app.py
 # The deploy prints a dedicated URL for this endpoint, e.g.
@@ -93,6 +100,22 @@ class Dubber:
         )
         return out_path
 
+    def _upload(self, path: str, put_url: str, content_type: str):
+        # Stream the file to the pre-signed GCS PUT URL. `data=<file object>` makes
+        # requests stream from disk in chunks — the file is never fully read into memory,
+        # so a big MP4 stays off the heap on both ends. Content-Type MUST match what the
+        # URL was signed with (the API binds it), or GCS rejects the PUT.
+        import requests
+
+        with open(path, "rb") as f:
+            resp = requests.put(
+                put_url,
+                data=f,
+                headers={"Content-Type": content_type},
+                timeout=600,
+            )
+        resp.raise_for_status()
+
     @modal.fastapi_endpoint(method="POST", docs=True)
     def dub(self, payload: dict):
         from fastapi import Response
@@ -102,6 +125,10 @@ class Dubber:
         reference_url = payload.get("reference_url")
         language = payload.get("language") or "en"
         is_video = bool(payload.get("is_video"))
+        output_put_url = payload.get("output_put_url")
+        output_content_type = payload.get("output_content_type") or (
+            "video/mp4" if is_video else "audio/wav"
+        )
         if not text or not reference_url:
             return Response(content="text and reference_url are required", status_code=400)
 
@@ -118,12 +145,15 @@ class Dubber:
         dubbed_wav = tempfile.NamedTemporaryFile(suffix=".wav", delete=False).name
         torchaudio.save(dubbed_wav, audio.cpu(), self.model.sr)
 
-        # Video in → mux the dubbed audio over the original video and return an MP4.
-        if is_video:
-            out_mp4 = self._mux(src_path, dubbed_wav)
-            with open(out_mp4, "rb") as f:
-                return Response(content=f.read(), media_type="video/mp4")
+        # Video in → mux the dubbed audio over the original video (MP4); audio in → the WAV.
+        out_path = self._mux(src_path, dubbed_wav) if is_video else dubbed_wav
+        media_type = "video/mp4" if is_video else "audio/wav"
 
-        # Audio in → return the dubbed WAV.
-        with open(dubbed_wav, "rb") as f:
-            return Response(content=f.read(), media_type="audio/wav")
+        # Preferred path: upload straight to GCS, keeping the bytes off the worker.
+        if output_put_url:
+            self._upload(out_path, output_put_url, output_content_type)
+            return {"ok": True}
+
+        # Fallback (no output_put_url): return the bytes — for local `modal run` / curl.
+        with open(out_path, "rb") as f:
+            return Response(content=f.read(), media_type=media_type)

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -558,13 +558,6 @@ Users can CRUD their own data:
 
 ## Storage Buckets
 
-### `dubbing_media` (public)
-**Purpose:** Store dubbing audio/video files  
-**Policies:**
-- Authenticated users: INSERT, SELECT, UPDATE, DELETE
-
----
-
 ### `user_avatar` (public)
 **Purpose:** Profile pictures  
 **Policies:**

--- a/packages/supabase/migrations/20260707000000_drop_dubbing_media_bucket.sql
+++ b/packages/supabase/migrations/20260707000000_drop_dubbing_media_bucket.sql
@@ -1,0 +1,15 @@
+-- Dubbing output moved from Supabase Storage to GCS (the GCS_DUBBING_BUCKET that already
+-- holds the input). Supabase's free tier caps objects at 50MB, which a dubbed MP4 blows
+-- past — see docs/dubbing-design.md. Modal now uploads the result straight to GCS via a
+-- signed PUT URL, so the `dubbing_media` bucket and its policies are dead weight.
+--
+-- Idempotent: safe to run whether or not the bucket/policies still exist.
+
+drop policy if exists "Authenticated users can delete from dubbing_media" on storage.objects;
+drop policy if exists "Authenticated users can read own uploads (for upsert)" on storage.objects;
+drop policy if exists "Authenticated users can upload to dubbing_media" on storage.objects;
+drop policy if exists "Authenticated users can upsert to dubbing_media" on storage.objects;
+
+-- Remove any leftover objects, then the bucket (delete would fail if the bucket is non-empty).
+delete from storage.objects where bucket_id = 'dubbing_media';
+delete from storage.buckets where id = 'dubbing_media';

--- a/packages/ui/src/templates/emails/early-access.tsx
+++ b/packages/ui/src/templates/emails/early-access.tsx
@@ -43,12 +43,12 @@ const EarlyAccessEmail = () => {
           <p className="text-gray-600 text-sm">
             &copy; {new Date().getFullYear()} Creator AI. All rights reserved.
           </p>
-          {/* <p className="text-gray-600 text-sm">
-            Questions? Reach out to me at{' '}
-            <a href="mailto:afrinnahar1999@gmail.com" className="text-purple-600 hover:underline">
-              support@your-script-ai-website.com
+          <p className="text-gray-600 text-sm">
+            Questions? Reach out to us at{' '}
+            <a href="mailto:support@tryscriptai.com" className="text-purple-600 hover:underline">
+              support@tryscriptai.com
             </a>
-          </p> */}
+          </p>
         </div>
       </div>
     </div>

--- a/packages/workers/src/processor/dubbing.processor.ts
+++ b/packages/workers/src/processor/dubbing.processor.ts
@@ -32,6 +32,9 @@ interface DubJobData {
   isVideo: boolean;
   targetLanguage: string;
   durationSeconds: number;
+  outputPutUrl: string;       // signed PUT URL — Modal uploads the dubbed file straight to GCS
+  outputContentType: string;  // must match the URL's signed Content-Type (video/mp4 | audio/wav)
+  outputPublicUrl: string;    // public GCS URL of the result, recorded once Modal confirms upload
 }
 
 @Processor('dubbing', { concurrency: 2 })
@@ -58,7 +61,10 @@ export class DubbingProcessor extends WorkerHost {
   }
 
   async process(job: Job<DubJobData>): Promise<{ dubbedUrl: string }> {
-    const { userId, projectId, inputGsUri, inputUrl, mimeType, isVideo, targetLanguage, durationSeconds } = job.data;
+    const {
+      userId, projectId, inputGsUri, inputUrl, mimeType, isVideo, targetLanguage, durationSeconds,
+      outputPutUrl, outputContentType, outputPublicUrl,
+    } = job.data;
 
     await job.updateProgress(0);
     await job.log('Starting dubbing...');
@@ -81,26 +87,20 @@ export class DubbingProcessor extends WorkerHost {
       const translatedText = await this.transcribeAndTranslate(inputGsUri, mimeType, languageLabel);
       await job.updateProgress(30);
 
-      // 2. Clone the voice + synthesize the translation (Modal GPU). For a video
-      //    input, Modal also muxes the dubbed audio back over the original video and
-      //    returns an MP4; for audio input it returns a WAV.
+      // 2. Clone the voice + synthesize the translation (Modal GPU), then have Modal
+      //    upload the result straight to GCS via the signed PUT URL — the worker never
+      //    holds the file (a dubbed MP4 can be hundreds of MB). For a video input Modal
+      //    muxes the dubbed audio over the original and stores an MP4; audio → a WAV.
       await this.throwIfCancelled(job.id!);
       await this.updateJob(projectId, { status: 'cloning' });
       await job.log(isVideo ? 'Cloning voice and rebuilding video...' : 'Cloning voice and generating dubbed audio...');
-      const dubbedMedia = await this.callModalDub(modalUrl, translatedText, inputUrl, isVideo, targetLanguage);
+      await this.callModalDub(modalUrl, translatedText, inputUrl, isVideo, targetLanguage, outputPutUrl, outputContentType);
       await job.updateProgress(80);
 
-      // 3. Store the result — MP4 for video dubs, WAV for audio (Supabase Storage).
+      // 3. Modal already stored the result in GCS at the pre-signed location.
       // Last cancellation window — after this we charge credits and persist.
       await this.throwIfCancelled(job.id!);
-      const filePath = isVideo ? `dubbed/${projectId}.mp4` : `dubbed/${projectId}.wav`;
-      const outputContentType = isVideo ? 'video/mp4' : 'audio/wav';
-      const { error: uploadError } = await this.supabase.storage
-        .from('dubbing_media')
-        .upload(filePath, dubbedMedia, { contentType: outputContentType, upsert: true });
-      if (uploadError) throw new Error(`Storage upload failed: ${uploadError.message}`);
-
-      const { data: urlData } = this.supabase.storage.from('dubbing_media').getPublicUrl(filePath);
+      const dubbedUrl = outputPublicUrl;
       await job.updateProgress(90);
 
       // 4. Deduct duration-based credits — only after a successful clone.
@@ -119,13 +119,13 @@ export class DubbingProcessor extends WorkerHost {
 
       await this.updateJob(projectId, {
         status: 'completed',
-        dubbed_url: urlData.publicUrl,
+        dubbed_url: dubbedUrl,
         credits_consumed: creditsConsumed,
       });
       await job.updateProgress(100);
       await job.log(`Done! ${creditsConsumed} credits deducted.`);
 
-      return { dubbedUrl: urlData.publicUrl };
+      return { dubbedUrl };
     } catch (error: any) {
       const cancelled = error instanceof DubbingCancelledError;
       await job.log(cancelled ? 'Cancelled by user.' : `Fatal error: ${error.message}`);
@@ -166,13 +166,15 @@ export class DubbingProcessor extends WorkerHost {
   }
 
   /**
-   * Modal contract: JSON { text, reference_url, is_video, language } → dubbed media.
-   * MODAL_API_URL is the exact URL `modal deploy` printed for the /dub endpoint — Modal
-   * gives each web endpoint its own dedicated hostname, there is no path routing on top
-   * of it, so we POST to modalUrl directly (no path appended). Modal fetches reference_url
-   * (public GCS URL), extracts audio if is_video, clones the voice and synthesizes `text`
-   * in `language`. When is_video it muxes the dubbed audio over the original video and
-   * returns an MP4 (video/mp4); otherwise a WAV (audio/wav). Also accepts { audio_base64 }.
+   * Modal contract: JSON { text, reference_url, is_video, language, output_put_url,
+   * output_content_type } → Modal uploads the dubbed file straight to GCS via the signed
+   * PUT URL and returns a small JSON ack. MODAL_API_URL is the exact URL `modal deploy`
+   * printed for the /dub endpoint — Modal gives each web endpoint its own dedicated
+   * hostname with no path routing, so we POST to modalUrl directly (no path appended).
+   * Modal fetches reference_url (public GCS URL), extracts audio if is_video, clones the
+   * voice, synthesizes `text` in `language`, muxes over the original video when is_video,
+   * and PUTs the result to output_put_url. Keeping the bytes off the worker is the point:
+   * the dubbed media never transits this process.
    */
   private async callModalDub(
     modalUrl: string,
@@ -180,11 +182,20 @@ export class DubbingProcessor extends WorkerHost {
     referenceUrl: string,
     isVideo: boolean,
     language: string,
-  ): Promise<Buffer> {
+    outputPutUrl: string,
+    outputContentType: string,
+  ): Promise<void> {
     const response = await fetch(modalUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, reference_url: referenceUrl, is_video: isVideo, language }),
+      body: JSON.stringify({
+        text,
+        reference_url: referenceUrl,
+        is_video: isVideo,
+        language,
+        output_put_url: outputPutUrl,
+        output_content_type: outputContentType,
+      }),
       signal: AbortSignal.timeout(MODAL_TIMEOUT_MS),
     });
 
@@ -192,17 +203,6 @@ export class DubbingProcessor extends WorkerHost {
       const errBody = await response.text().catch(() => 'Unknown error');
       throw new Error(`Modal API error ${response.status}: ${errBody.slice(0, 500)}`);
     }
-
-    const contentType = response.headers.get('content-type') || '';
-    if (contentType.includes('audio') || contentType.includes('video') || contentType.includes('octet-stream')) {
-      return Buffer.from(await response.arrayBuffer());
-    }
-
-    const jsonBody = (await response.json()) as Record<string, unknown>;
-    for (const key of ['audio_base64', 'audio', 'data']) {
-      if (typeof jsonBody[key] === 'string') return Buffer.from(jsonBody[key] as string, 'base64');
-    }
-    throw new Error('Unexpected response format from Modal dubbing API');
   }
 
   private async updateJob(projectId: string, fields: Record<string, any>) {


### PR DESCRIPTION
## Audio dubbing feature

Adds AI voice-dubbing: a user uploads audio/video, picks a target language, and gets back the same media dubbed in a cloned version of the original speaker's voice.

### Pipeline
1. **Upload** → browser PUTs the source straight to the `GCS_DUBBING_BUCKET` via a signed URL (API never touches the bytes). Plan-gated to paid tiers; 500MB cap.
2. **Transcribe + translate** → Gemini (Vertex) reads the media from `gs://` and returns the translated text.
3. **Clone + synthesize** → a Modal serverless-GPU service (Chatterbox Multilingual) clones the speaker's voice and synthesizes the translation; for video it muxes the dubbed audio back over the original.
4. **Store** → the dubbed file lands in GCS; the worker records the public URL and deducts duration-based credits.

Progress streams to the browser over SSE; jobs are cancellable mid-run.

### Storage & worker-memory design (latest commits)
The output was originally written to a Supabase Storage bucket, which caps objects at 50MB on the free tier — a dubbed MP4 blows past that with `object exceeded the maximum allowed size`. Fixed by:

- **Output moved to GCS** (`GCS_DUBBING_BUCKET`, alongside the input) — the API mints a long-lived signed PUT URL at enqueue and hands it to the worker.
- **Modal uploads directly to GCS** via that URL, so the dubbed media never round-trips through the Node worker (previously it was fully buffered in RAM). Modal streams the file with a chunked PUT.
- Supabase `dubbing_media` bucket + policies dropped via migration; `deleteDub` now cleans up both GCS objects.

Also included: surfacing `support@tryscriptai.com` across the public pages (footer, FAQ, contact, blog).

### Testing
- `apps/api` dubbing unit tests pass (14).
- `packages/workers` builds clean.

### Follow-up notes
- Output signed-PUT URL has a 2h TTL (minted at enqueue, consumed by Modal post-processing); comfortably covers the concurrency-2 queue. If backlogs ever exceed it, mint the URL in the worker instead.
- Deploying requires `GCS_DUBBING_BUCKET`, `MODAL_API_URL`, and GCS signing perms on the API's service account (same requirement the subtitle uploader already uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
