### PR TITLE
feat(blog): add two audio dubbing posts with YouTube embed

### DIFF
--- a/apps/web/app/blog/[id]/page.tsx
+++ b/apps/web/app/blog/[id]/page.tsx
@@ -139,6 +139,30 @@ const markdownComponents: Components = {
       </a>
     )
   },
+  // A YouTube URL as a markdown image renders as a responsive embed; anything
+  // else falls back to a normal image. Lets posts embed video without raw HTML.
+  img: ({ src, alt }) => {
+    const url = typeof src === "string" ? src : ""
+    const yt = url.match(
+      /(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([\w-]{11})/
+    )
+    if (yt) {
+      return (
+        <span className="block my-8 aspect-video w-full overflow-hidden rounded-xl border border-slate-200 shadow-sm">
+          <iframe
+            src={`https://www.youtube-nocookie.com/embed/${yt[1]}`}
+            title={alt || "YouTube video player"}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            loading="lazy"
+            className="h-full w-full"
+          />
+        </span>
+      )
+    }
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={url} alt={alt || ""} className="my-8 w-full rounded-xl border border-slate-200" />
+  },
 }
 
 export default function BlogDetailPage() {

--- a/apps/web/lib/blog-data.ts
+++ b/apps/web/lib/blog-data.ts
@@ -2839,6 +2839,342 @@ Pair AI scripting with [how to write YouTube scripts that get more views](/blog/
 - Dig into [YouTube audience retention metrics](https://support.google.com/youtube/answer/1714329) in YouTube Help.
     `,
   },
+  {
+    slug: "youtube-auto-dubbing-vs-ai-voice-cloning",
+    title: "YouTube Auto-Dubbing vs AI Voice Cloning: Why Your Dub Sounds Robotic",
+    excerpt:
+      "YouTube's free auto-dub gets your words into 27 languages, but it uses a stranger's voice, not yours. Here's why that quietly kills retention, and how voice cloning fixes it.",
+    category: "Audio Dubbing",
+    author: "Creator AI Team",
+    date: "Jul 8, 2026",
+    readTime: "12 min read",
+    featured: false,
+    tags: ["Audio Dubbing", "Voice Cloning", "YouTube", "Localization"],
+    seoTitle: "YouTube Auto-Dubbing vs AI Voice Cloning (2026)",
+    seoDescription:
+      "YouTube auto-dubbing uses a generic voice that tanks retention. See why voice cloning wins and how to dub YouTube videos in your own voice in 2026.",
+    keywords: [
+      "voice cloning vs youtube dubbing",
+      "youtube auto-dubbing alternative",
+      "how to dub youtube videos in your own voice",
+      "why does youtube auto-dubbing sound robotic",
+      "does youtube auto-dubbing use your real voice",
+      "ai voice cloning youtube",
+    ],
+    faqs: [
+      {
+        question: "Does YouTube auto-dubbing use your real voice?",
+        answer:
+          "No. YouTube auto-dubbing uses a generic synthesized voice, not a clone of the creator. Voice cloning tools like Creator AI preserve your actual voice so every dubbed language still sounds like you.",
+      },
+      {
+        question: "Why does YouTube auto-dubbing sound robotic?",
+        answer:
+          "It relies on generic text-to-speech with no voice cloning, and it struggles with humor, idioms, slang, accents, and emotional delivery. YouTube itself warns that dubs may contain errors and that quality varies by language.",
+      },
+      {
+        question: "Is AI dubbing worth it for YouTube?",
+        answer:
+          "Yes for reach, but only voice-preserving dubbing protects retention. AIR Media-Tech found that swapping a real dub for a generic AI voice dropped viewer retention 4x to 5x, which sends negative signals to the algorithm across your whole channel.",
+      },
+      {
+        question: "How do I dub my YouTube videos in my own voice?",
+        answer:
+          "Use a voice-cloning dubbing tool. Creator AI trains on your channel audio, clones your voice, translates the script, and generates a dub that keeps your tone and phrasing, instead of YouTube's default synthetic narrator.",
+      },
+      {
+        question: "Can I edit YouTube's auto dubs?",
+        answer:
+          "No. YouTube's native auto-dubbing is review-or-reject only, you cannot fine-tune the translation or delivery. Dedicated dubbing tools let you edit the script, voice, and pacing before you publish.",
+      },
+      {
+        question: "Is it legal to clone your own voice for dubbing?",
+        answer:
+          "Yes. Voice cloning is legal when you own the voice or have consent, and dubbing your own channel is a non-issue. Creator AI is clone-your-own-voice by design, which keeps you consent-clean ahead of the EU AI Act's Article 50 transparency rules taking full effect in August 2026.",
+      },
+    ],
+    content: `
+> **Does YouTube auto-dubbing use your real voice?** No. YouTube's native auto-dubbing uses a generic synthesized voice, not a clone of the creator. It translates your words into 27 languages for free, but viewers in those languages hear a competent stranger, not you. Voice-cloning tools like Creator AI preserve your actual voice so the dub still sounds like the person your audience subscribed to.
+
+YouTube's native auto-dubbing went fully public in early 2026. As of February it covers 27 languages and is open to essentially every eligible creator, not just Partner Program members. YouTube reported that in December 2025 more than 6 million people per day watched at least 10 minutes of auto-dubbed content. The demand is real and validated.
+
+So the question in 2026 isn't *should* you dub. YouTube already settled that. The question is *with what voice*, because the free default ships with a hidden cost that doesn't show up until you read your retention graph.
+
+![Creator AI audio dubbing walkthrough](https://www.youtube.com/watch?v=Yg4J8mUJo-M)
+
+## Does YouTube Auto-Dubbing Use Your Real Voice?
+
+No. This is the single most important thing to understand before you flip the switch in Studio.
+
+YouTube's auto-dub takes your script, translates it, and reads it back with a generic text-to-speech voice. It added "Expressive Speech" in eight languages (English, French, German, Hindi, Indonesian, Italian, Portuguese, Spanish) to better mirror pitch and intonation, and for calm, single-speaker, well-scripted content it dubs nearly perfectly. But "nearly perfect" describes the *translation*, not the *identity*. The voice isn't yours.
+
+Your audience didn't subscribe to your words. They subscribed to you, your timing, your dry jokes, the way you land a punchline. Strip that out and you've handed your Spanish and Hindi viewers a translation read by someone they've never met.
+
+The industry term for what's missing is **voice preservation**, or **vocal identity**. It's the exact thing the free tool doesn't do, and it's the whole ballgame.
+
+## Why Does YouTube Auto-Dubbing Sound Robotic?
+
+Three reasons, and they compound:
+
+1. **Generic TTS, no cloning.** The model was never trained on your voice, so it defaults to a neutral synthetic narrator.
+2. **It breaks on the human stuff.** Humor, idioms, slang, heavy accents, emotional or stylized delivery, and technical terminology are exactly where generic dubbing falls apart. YouTube itself acknowledges dubs may contain errors from incorrect speech recognition and warns that quality varies by language.
+3. **You can't fix it.** Auto dubs are review-or-reject, not fine-tune. You get a yes/no, not an editor.
+
+And every auto-dubbed video carries an "auto-dubbed" label, which a slice of your audience reads as lower-effort AI content before they've even pressed play.
+
+The honest framing: YouTube solved *reach*. It did not solve *connection*. The free tool gets your words into another language. It doesn't get you across.
+
+## The Retention Problem Nobody Warns You About
+
+Here's the data point your whole dubbing strategy should orbit around.
+
+> AIR Media-Tech ran controlled tests replacing professional dubs with generic AI voice tracks across dozens of channels. Retention dropped 4x to 5x, just from swapping the voice. On one kids channel the bad dub dragged down the entire channel's average watch time, sending negative signals to the algorithm and hurting visibility on every video, not only the dubbed ones. Their blunt conclusion: low retention equals low revenue, and generic AI dubbing still can't keep viewers watching.
+
+Read that twice. A robotic dub doesn't just fail to grow the new market. It can *poison the algorithm for your whole channel*, because YouTube treats collapsing watch time as a signal that your content isn't satisfying anyone.
+
+That's why "free" isn't free. The sticker price is zero. The retention bill arrives later.
+
+Pair that with the demand side: 72 to 76% of consumers prefer content in their native language (the CSA Research figure everyone cites). People want their language *and* they want the real creator. Only voice cloning delivers both at once.
+
+## Voice Cloning vs YouTube Dubbing: Side by Side
+
+| Feature | YouTube Auto-Dub | AI Voice Cloning (Creator AI) |
+|---------|------------------|-------------------------------|
+| Cost | Free | Paid, inside your existing suite |
+| Voice | Generic synthesized | Cloned from your real voice |
+| Languages | 27 | 20+ and growing |
+| Sounds like you | ❌ | ✅ |
+| Editable before publish | ❌ Review-or-reject | ✅ Script, voice, pacing |
+| Handles humor / tone | Weak | Trained on your channel data |
+| "Auto-dubbed" label | Always | No |
+| Retention impact | Can drop 4–5x | Preserves the original |
+
+**Before:** You enable auto-dub, get 27 languages overnight, and watch your non-English retention flatline while a synthetic voice reads your jokes with no timing.
+
+**After:** Creator AI clones your voice, so a viewer in Mexico City or Mumbai hears *you*, in their language, with your phrasing intact.
+
+## Voice Preservation Is the Thing the Free Tool Can't Do
+
+This is where the market has already moved. DittoDub built its entire pitch on voice cloning that preserves the original speaker's tone, emotion, and vocal identity. Fish Audio leads with the creator whose narration gets cloned into Spanish, Japanese, and Hindi and still sounds like them in every version. The category has decided that vocal identity is the deciding factor. YouTube's free tool hasn't caught up.
+
+Creator AI clones your actual voice so every dubbed language still sounds like you, not a robotic default and not an unrelated voice actor. And because it trains on your channel data, the dub carries your phrasing and tone rather than generic model output. It's the same thread that runs through the rest of the product, "trains on your channel so everything sounds like you", just extended to a new language. [See how Creator AI learns your voice →](/blog/how-creator-ai-learns-your-voice)
+
+## How to Dub YouTube Videos in Your Own Voice
+
+You don't need a studio or a five-tool pipeline. The workflow is short:
+
+1. **Connect your channel** so the tool has real audio of you to learn from.
+2. **Clone your voice** once, then reuse it across every language.
+3. **Translate the script**, then have a native speaker sanity-check flow, jokes, and pacing.
+4. **Generate the dub** in your cloned voice and review the delivery before publishing.
+
+AIR Media-Tech's own best-practice list is worth adopting because it signals you care about quality, not just features:
+
+- Get the translation reviewed by a native speaker for flow and jokes.
+- Train the AI voice on real audio of the creator so it reflects actual tone. (This is literally what cloning does.)
+- Always have a fluent speaker sanity-check the final output.
+- Follow the 80/20 rule: let AI carry the factual and educational stretches, keep human emotion in intros and personal moments.
+
+Creator AI makes steps 1 and 2 automatic, because it trains on your channel data and clones your voice, collapsing what used to be a multi-step manual process into one workflow. [Try dubbing in your own voice free →](/signup)
+
+## Is Voice-Preserving Dubbing Worth It?
+
+For reach, yes. But be precise about *why*: dubbing only makes money if people keep watching. YouTube counts watch time from dubbed videos toward channel revenue, and each dubbed view earns that region's CPM. Creators who upload custom multi-language audio see 25%+ of total watch time come from non-primary languages, and cross-language audio has lifted total views by up to 45%.
+
+A robotic dub that tanks retention 4–5x doesn't just fail to convert that reach, it can drag your whole channel down with it. Voice-preserving dubbing is what turns new-language reach into actual watch time and revenue.
+
+One more reason it's worth doing right: **it's consent-clean by design.** Voice cloning is legal when you own the voice or have consent, and cloning your own channel is a non-issue. With the EU AI Act's Article 50 transparency rules taking full effect in August 2026, clone-your-own-voice is the safe default.
+
+## The Bottom Line
+
+YouTube gave every creator free reach into 27 languages, and that's genuinely valuable. But it dubs your words with a stranger's voice, and the retention data says viewers feel that disconnect even when they can't name it. Reach without retention is a vanity metric.
+
+The creators who win the multi-language game in 2026 won't be the ones who dubbed first. They'll be the ones who dubbed *as themselves*.
+
+## Keep Reading
+
+- [Best AI Dubbing Tool for YouTubers in 2026 (Compared)](/blog/best-ai-dubbing-tool-for-youtubers-2026)
+- [How Creator AI Learns Your Voice](/blog/how-creator-ai-learns-your-voice)
+- [YouTube Scripts That Keep Viewers Watching](/blog/youtube-scripts-that-keep-viewers-watching)
+- [Dub in your own voice, start free →](/signup) · [See features](/features) · [View pricing](/pricing)
+    `,
+  },
+  {
+    slug: "best-ai-dubbing-tool-for-youtubers-2026",
+    title: "Best AI Dubbing Tool for YouTubers in 2026 (Compared)",
+    excerpt:
+      "We compared the top AI dubbing tools for creators on price, voice cloning, lip-sync, and languages, from YouTube's free auto-dub to ElevenLabs, HeyGen, Rask, and Creator AI.",
+    category: "Audio Dubbing",
+    author: "Creator AI Team",
+    date: "Jul 8, 2026",
+    readTime: "13 min read",
+    featured: false,
+    tags: ["Audio Dubbing", "AI Tools", "Comparison", "YouTube"],
+    seoTitle: "Best AI Dubbing Tool for YouTubers in 2026 (Compared)",
+    seoDescription:
+      "Best AI dubbing tool for YouTubers 2026: compare YouTube auto-dub, ElevenLabs, HeyGen, Rask, and Creator AI on price, voice cloning, and languages.",
+    keywords: [
+      "best ai dubbing tool for youtubers",
+      "ai dubbing for creators 2026",
+      "ai dubbing tool comparison",
+      "elevenlabs vs heygen dubbing",
+      "how much does ai dubbing cost",
+      "voice cloning dubbing tool youtube",
+    ],
+    faqs: [
+      {
+        question: "What is the best AI dubbing tool for YouTubers in 2026?",
+        answer:
+          "Creator AI is the best fit for YouTubers who want voice-cloned dubbing inside the same suite as their scripts, thumbnails, and subtitles. ElevenLabs leads on raw English voice quality, HeyGen on lip-sync, and YouTube's free auto-dub on zero-effort reach, but none clone your voice and keep it in one workflow.",
+      },
+      {
+        question: "How much does AI dubbing cost?",
+        answer:
+          "Roughly $1 to $10 per minute for AI dubbing versus $50 to $200 per minute for studio dubbing, up to about 90% cheaper. YouTube's native auto-dub is free but uses a generic voice you can't edit.",
+      },
+      {
+        question: "Which AI dubbing tools clone the creator's voice?",
+        answer:
+          "Creator AI, ElevenLabs, DittoDub, and Fish Audio preserve the creator's voice. YouTube auto-dub and HeyGen's translation often use synthetic or substitute voices, so the same person suddenly sounds different in another language.",
+      },
+      {
+        question: "Is ElevenLabs or HeyGen better for dubbing?",
+        answer:
+          "ElevenLabs wins on voice quality, especially in English, but is audio-only and needs a separate video editor. HeyGen wins on lip-sync across 175+ languages but often uses synthetic voices instead of cloning the original speaker. Your choice depends on whether voice identity or lip-sync matters more.",
+      },
+      {
+        question: "Does AI dubbing actually make money on YouTube?",
+        answer:
+          "Yes, when retention holds. YouTube counts dubbed watch time toward revenue at each region's CPM, and creators with custom multi-language audio see 25%+ of watch time from non-primary languages. But a robotic dub that drops retention 4–5x can hurt your whole channel, so voice quality is the deciding factor.",
+      },
+      {
+        question: "Do I still need a separate video editor for AI dubbing?",
+        answer:
+          "With audio-only tools like ElevenLabs, yes, you stitch the dubbed track back into the video yourself. Creator AI keeps dubbing inside the same suite as your scripts, thumbnails, and subtitles, so you're not juggling five tools and a credit calculator.",
+      },
+    ],
+    content: `
+> **What is the best AI dubbing tool for YouTubers?** The best AI dubbing tool depends on what you value, but for creators the deciding factor in 2026 is voice cloning: does the dub still sound like you? Creator AI clones your voice and keeps dubbing in the same suite as your scripts, thumbnails, and subtitles. ElevenLabs leads on English voice quality, HeyGen on lip-sync, and YouTube's free auto-dub on effortless reach, but the free and cheap options either skip cloning or force you to stitch audio back into video yourself.
+
+Dubbing is now table stakes. YouTube's native auto-dub covers 27 languages, reaches millions daily, and made "should I dub" a settled question. So this guide isn't about *whether* to dub. It's about picking a tool that grows your channel instead of quietly hurting it, because a generic dub can drop retention 4–5x and drag down every video you've published.
+
+![Creator AI audio dubbing walkthrough](https://www.youtube.com/watch?v=Yg4J8mUJo-M)
+
+## What Makes the Best AI Dubbing Tool for YouTubers?
+
+Ignore the feature checklists for a second. For a creator, four things actually decide whether a dub grows your channel:
+
+1. **Voice cloning.** Does the dub sound like *you*, or a stranger? This is the retention lever. Generic voices can cut retention 4–5x (AIR Media-Tech's controlled tests), and 72–76% of consumers already prefer content in their native language (CSA Research), so the winning combo is *their language, your voice*.
+2. **Workflow.** Is dubbing one more standalone subscription, or does it live next to your scripts, thumbnails, and subtitles?
+3. **Editability.** Can you fix the translation and delivery before publishing, or is it review-or-reject?
+4. **Honest pricing.** Per-minute? Per-language? Shared credit pool? The gotchas hide here.
+
+## Best AI Dubbing Tools for YouTubers 2026: Comparison
+
+| Tool | Price (2026) | Voice Cloning | Lip-Sync | Languages | Best For |
+|------|--------------|---------------|----------|-----------|----------|
+| **Creator AI** | Paid, all-in-one suite | ✅ Trained on your channel | Roadmap | 20+ | Creators who want voice + full workflow in one place |
+| **YouTube Auto-Dub** | Free | ❌ Generic voice | ❌ | 27 | Zero-budget, educational, single-speaker |
+| **ElevenLabs** | Free → $330/mo (credit-based) | ✅ Best-in-class (English) | ❌ Audio only | 32 | Highest English voice quality |
+| **HeyGen** | $29 → $149/mo | ⚠️ Often synthetic | ✅ Best-in-class | 175+ | Avatar and lip-sync first |
+| **Rask AI** | $19 → ~$50+/mo | ✅ | Add-on | 130+ | Interviews, panels, multi-speaker |
+| **Dubverse** | Budget tiers | Limited | ❌ | ~30 | Light, budget dubbing |
+
+The through-line: the tools that actually preserve your voice (Creator AI, ElevenLabs, DittoDub, Fish Audio) are the premium play. The free and cheap options either don't clone the voice or make you stitch audio back into video yourself.
+
+## 1. Creator AI, Best for Voice + Full Workflow
+
+**Why it wins for creators:** Creator AI clones your actual voice so every dubbed language still sounds like you, and because it trains on your channel data the dub carries your phrasing and tone, not generic model output. The bigger edge is that dubbing lives inside the same suite as your scripts, thumbnails, titles, and subtitles. You're not juggling five tools and a credit calculator.
+
+**Before:** Script in one tool, thumbnail in Canva, subtitles in a third app, dubbing in a fourth with its own credit math, and audio you stitch back into the video yourself.
+
+**After:** One dashboard from script to dubbed, voice-matched upload.
+
+**Best for:** Creators who publish regularly, care about voice consistency, and want localization to be a step in their pipeline instead of a separate project. [Try dubbing in your own voice free →](/signup)
+
+## 2. YouTube Native Auto-Dub, Best Free Option
+
+Credit where it's due: it's free, zero-effort, built into Studio, covers 27 languages, and added Expressive Speech in eight of them. For calm, single-speaker, well-scripted educational content it dubs nearly perfectly.
+
+**Where it breaks:** generic synthesized voice (not you), weak on humor, idioms, slang, accents, and emotion, no editing (review-or-reject), and an "auto-dubbed" label on every video. YouTube itself warns dubs may contain recognition errors and vary by language. Great for reach, risky for retention. [Full breakdown: auto-dubbing vs voice cloning →](/blog/youtube-auto-dubbing-vs-ai-voice-cloning)
+
+## 3. ElevenLabs, Best English Voice Quality
+
+Best-in-class voice quality, especially in English, with 32 languages, though quality drops noticeably outside English and Western European languages.
+
+**Two gotchas to know before you commit:**
+
+- **Every language is billed separately.** A 10-minute video into 3 languages counts as 30 minutes of usage.
+- **One shared credit pool.** Dubbing draws from the same credits as TTS, cloning, and everything else.
+
+Pricing is credit-based and famously confusing: Free (~10 min), Starter $5/mo, Creator $22/mo (~50 dubbing min, $0.60/min overage), Pro $99/mo (~250 min, $0.24/min overage), Scale $330/mo, Business $1,320/mo, with a headline rate around $0.18/min cited. And it's audio-only, so you'll need a separate video editor.
+
+**Best for:** Creators who want the absolute best English voice and don't mind assembling the video themselves.
+
+## 4. HeyGen, Best Lip-Sync
+
+Best-in-class lip-sync across 175+ languages, avatar-first. Credit-based: Creator $29/mo, Pro $49+/mo, Business $149/mo. Audio dubbing is cheap at 2 credits/min, full lip-sync translation 5 credits/min.
+
+**The catch for creator content:** its translation often uses synthetic voices rather than cloning the original speaker, so the same person suddenly sounds different in another language, which is exactly the disconnect that hurts retention.
+
+**Best for:** Talking-head and avatar content where matching mouth movement matters more than preserving your exact voice.
+
+## 5. Rask AI, Best for Multi-Speaker
+
+130+ languages with strong multi-speaker detection. Basic from $19/mo, lip-sync from ~$50/mo, 14 free trial minutes.
+
+**Best for:** Interviews, panels, and podcasts where clean speaker separation matters.
+
+## 6. Dubverse, Budget Pick
+
+Around 30 languages and more limited overall. A reasonable choice for light, budget-conscious dubbing where voice identity isn't the priority.
+
+## AI vs Traditional Dubbing: The Cost Reality
+
+If you're weighing AI against a studio at all, the numbers are stark:
+
+| Approach | Cost per minute | Time per language | Naturalness |
+|----------|-----------------|-------------------|-------------|
+| Traditional studio | $50–200 | 1–4 weeks | ~100% |
+| AI dubbing | $1–10 | 5–15 minutes | 90–95% (best cloning) |
+
+The quality gap has narrowed to where most viewers can't tell the difference on short-form. Traditional still wins for broadcast TV, feature films, and big-budget brand campaigns. AI wins decisively for creator content, product demos, and channel growth, which is exactly this audience.
+
+## How Much Does AI Dubbing Cost?
+
+Roughly **$1 to $10 per minute** for AI versus $50 to $200 per minute for studio, up to about 90% cheaper. YouTube's auto-dub is free but generic and uneditable. Watch for the pricing traps: per-language billing (ElevenLabs) and shared credit pools that quietly drain into TTS and cloning. An all-in-one suite avoids the credit-calculator tax entirely.
+
+## The Monetization Math
+
+The reason any of this matters: dubbing is a revenue lever, not a vanity feature. YouTube counts watch time from dubbed videos toward channel revenue, and each dubbed view earns that region's CPM. Creators who upload custom multi-language audio see 25%+ of total watch time come from non-primary languages, and cross-language audio has lifted total views by up to 45%.
+
+One widely cited illustrative model: a creator earning $5,000/mo from 100K English viewers could reach around $40,000/mo from 800K translated viewers at similar RPMs. Treat that as aspirational, not a promise, but the direction is real.
+
+Here's the sharp version: **dubbing only makes money if people keep watching.** A robotic dub that tanks retention 4–5x doesn't just fail to grow the new market, it poisons the algorithm for your whole channel. So the cheapest tool with the worst voice can be the most expensive choice you make. Voice-preserving dubbing is what makes reach convert to watch time.
+
+## How to Choose
+
+- **You want your voice preserved and one workflow →** Creator AI.
+- **You want the best English voice and will edit video yourself →** ElevenLabs.
+- **You need lip-sync above all →** HeyGen.
+- **You dub interviews and panels →** Rask AI.
+- **You want free reach and accept a generic voice →** YouTube auto-dub.
+
+## A Quick Legal Note
+
+Voice cloning is legal when you own the voice or have consent, so dubbing your own channel is a non-issue. It's only a concern with third-party voices. The EU AI Act's Article 50 transparency requirements take full effect in August 2026, which makes clone-your-own-voice tools the consent-clean default.
+
+## The Bottom Line
+
+The best AI dubbing tool for *you* is the one that keeps viewers watching in every language, and that comes down to voice. Free and cheap tools get your words translated. Voice-cloning tools keep *you* in the room. For creators who want that plus a workflow that doesn't sprawl across five subscriptions, Creator AI is the tool built for the job.
+
+## Keep Reading
+
+- [YouTube Auto-Dubbing vs AI Voice Cloning: Why Your Dub Sounds Robotic](/blog/youtube-auto-dubbing-vs-ai-voice-cloning)
+- [How Creator AI Learns Your Voice](/blog/how-creator-ai-learns-your-voice)
+- [Start dubbing in your own voice free →](/signup) · [See features](/features) · [View pricing](/pricing)
+    `,
+  },
 ];
 
 export function getBlogBySlug(slug: string): BlogPost | undefined {


### PR DESCRIPTION
## What

Adds two SEO/AEO-optimized blog posts about the audio dubbing feature, following the existing blog architecture in `apps/web/lib/blog-data.ts`:

1. **YouTube Auto-Dubbing vs AI Voice Cloning: Why Your Dub Sounds Robotic** — the retention / voice-preservation angle. Leads with the AIR Media-Tech 4–5x retention-drop stat as a pull-quote.
2. **Best AI Dubbing Tool for YouTubers in 2026 (Compared)** — competitor comparison table (YouTube auto-dub, ElevenLabs, HeyGen, Rask, Dubverse, Creator AI), cost breakdown, and monetization math.

Both posts embed the feature walkthrough video (`Yg4J8mUJo-M`).

## How it fits the existing architecture

Both posts use the same `BlogPost` interface and conventions as existing posts:
- `> **Question?**` AEO answer block up top
- H2s phrased as the target questions
- GFM comparison tables (rendered via `BlogTable`)
- Retention stat as a blockquote pull-quote
- `faqs` array → visible FAQ block + `FAQPage` JSON-LD (already wired in the `[id]/layout.tsx`)
- Internal CTAs to `/signup`, `/features`, `/pricing` and cross-links

Everything downstream (listing grid, sitemap, metadata, article + breadcrumb + FAQPage JSON-LD, related posts) derives automatically from the `blogPosts` array, so no other wiring was needed.

## One code change

`apps/web/app/blog/[id]/page.tsx`: added an `img` markdown component override. react-markdown renders no raw HTML, so there was no way to embed a real player before. A YouTube URL written as a markdown image now renders as a responsive `youtube-nocookie` iframe; any other URL falls back to a normal `<img>`. No new dependencies.

## Notes

- New category `"Audio Dubbing"` so the two posts relate to each other and stand apart from the ChatGPT cluster.
- Both set `featured: false` — the listing shows only the first featured post and filters all other `featured: true` posts out of the grid, so a featured post would have been invisible on `/blog`.

## Verification

- `tsc --noEmit` passes clean on `apps/web`.