### PR TITLE
feat(hannah): AI guide chatbot for public site and dashboard

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -23,6 +23,7 @@ import { IdeationModule } from './ideation/ideation.module';
 import { BillingModule } from './billing/billing.module';
 import { AdminModule } from './admin/admin.module';
 import { AffiliateModule } from './affiliate/affiliate.module';
+import { HannahModule } from './hannah/hannah.module';
 
 @Module({
   imports: [
@@ -64,6 +65,7 @@ import { AffiliateModule } from './affiliate/affiliate.module';
     BillingModule,
     AdminModule,
     AffiliateModule,
+    HannahModule,
   ],
   controllers: [AppController, HealthController],
   providers: [],

--- a/apps/api/src/hannah/hannah.controller.spec.ts
+++ b/apps/api/src/hannah/hannah.controller.spec.ts
@@ -1,0 +1,19 @@
+import { allowRequest } from './hannah.controller';
+
+describe('allowRequest (Hannah rate limiter)', () => {
+  it('allows up to max, blocks the next, then recovers after the window', () => {
+    const store = new Map<string, number[]>();
+    const t = 1_000_000;
+
+    // 3 allowed within window
+    expect(allowRequest(store, 'ip', t, 1000, 3)).toBe(true);
+    expect(allowRequest(store, 'ip', t + 1, 1000, 3)).toBe(true);
+    expect(allowRequest(store, 'ip', t + 2, 1000, 3)).toBe(true);
+    // 4th blocked
+    expect(allowRequest(store, 'ip', t + 3, 1000, 3)).toBe(false);
+    // after the window elapses, old hits expire -> allowed again
+    expect(allowRequest(store, 'ip', t + 1001, 1000, 3)).toBe(true);
+    // separate IP is independent
+    expect(allowRequest(store, 'other', t + 3, 1000, 3)).toBe(true);
+  });
+});

--- a/apps/api/src/hannah/hannah.controller.ts
+++ b/apps/api/src/hannah/hannah.controller.ts
@@ -1,0 +1,113 @@
+import { Controller, Post, Body, Req, UseGuards, HttpException, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
+import { z } from 'zod';
+import type { Request } from 'express';
+import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import type { AuthRequest } from '../common/interfaces/auth-request.interface';
+import { getUserId } from '../common/get-user-id';
+import { HannahService, type HannahMessage } from './hannah.service';
+
+const ChatSchema = z.object({
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'assistant']),
+        content: z.string().trim().min(1).max(2000),
+      }),
+    )
+    .min(1)
+    .max(20), // bounds prompt size -> bounds Vertex cost per request
+  // Current-turn voice message (base64). ~2.8M base64 chars ≈ 2MB ≈ 60s of opus.
+  audio: z
+    .object({
+      data: z.string().min(1).max(2_800_000),
+      mimeType: z.enum(['audio/webm', 'audio/ogg', 'audio/mp4', 'audio/mpeg', 'audio/wav']),
+    })
+    .optional(),
+});
+type ChatInput = z.infer<typeof ChatSchema>;
+
+const CHAT_BODY_SCHEMA = {
+  schema: {
+    type: 'object' as const,
+    required: ['messages'],
+    properties: {
+      messages: {
+        type: 'array' as const,
+        items: {
+          type: 'object' as const,
+          properties: {
+            role: { type: 'string' as const, enum: ['user', 'assistant'] },
+            content: { type: 'string' as const },
+          },
+        },
+      },
+    },
+  },
+};
+
+// ponytail: in-memory sliding-window limiter — fine for a single API instance.
+// Move to Redis (redis.ts is already wired) if the API scales horizontally.
+const WINDOW_MS = 60_000;
+const MAX_PER_WINDOW = 20;
+const hits = new Map<string, number[]>();
+
+/** Pure sliding-window check. Returns true if the request is allowed (and records it). */
+export function allowRequest(
+  store: Map<string, number[]>,
+  ip: string,
+  now: number,
+  windowMs = WINDOW_MS,
+  max = MAX_PER_WINDOW,
+): boolean {
+  const recent = (store.get(ip) ?? []).filter((t) => now - t < windowMs);
+  if (recent.length >= max) {
+    store.set(ip, recent);
+    return false;
+  }
+  recent.push(now);
+  store.set(ip, recent);
+  return true;
+}
+
+function rateLimitOrThrow(key: string) {
+  if (!allowRequest(hits, key, Date.now())) {
+    throw new HttpException('Too many messages. Please slow down a moment.', HttpStatus.TOO_MANY_REQUESTS);
+  }
+}
+
+@ApiTags('hannah')
+@Controller('hannah')
+export class HannahController {
+  constructor(private readonly hannahService: HannahService) {}
+
+  @Post('chat')
+  @ApiOperation({
+    summary: 'Chat with Hannah on the public site (anonymous)',
+    description: 'Answers feature/pricing/general questions only. No user data.',
+  })
+  @ApiBody(CHAT_BODY_SCHEMA)
+  async chat(@Body(new ZodValidationPipe(ChatSchema)) body: ChatInput, @Req() req: Request) {
+    const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.ip || 'unknown';
+    rateLimitOrThrow(ip);
+    return this.hannahService.chat(body.messages as HannahMessage[], 'public', undefined, body.audio as { data: string; mimeType: string } | undefined);
+  }
+
+  @Post('chat/dashboard')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Chat with Hannah inside the dashboard (authenticated)',
+    description: "Includes the signed-in user's account snapshot (plan, credits, activity) in Hannah's context.",
+  })
+  @ApiBody(CHAT_BODY_SCHEMA)
+  async chatDashboard(
+    @Body(new ZodValidationPipe(ChatSchema)) body: ChatInput,
+    @Req() req: AuthRequest,
+  ) {
+    const userId = getUserId(req);
+    rateLimitOrThrow(userId); // per-user, not per-IP — authed users behind one NAT don't starve each other
+    return this.hannahService.chat(body.messages as HannahMessage[], 'dashboard', userId, body.audio as { data: string; mimeType: string } | undefined);
+  }
+}

--- a/apps/api/src/hannah/hannah.knowledge.ts
+++ b/apps/api/src/hannah/hannah.knowledge.ts
@@ -1,0 +1,57 @@
+/**
+ * Hannah's persona + the Creator AI knowledge base she answers from.
+ *
+ * This is the single source of truth for what Hannah knows. Reference links are
+ * site-relative paths so the frontend renders them as in-app links. Keep feature
+ * copy in sync with `apps/web/app/features/page.tsx`.
+ */
+
+const FEATURES = `
+CORE FEATURES (each consumes credits; all are personalized once AI Studio is trained):
+
+- AI Studio — Connect a YouTube channel, pick 3–5 of your best videos, and the AI learns your tone, vocabulary, pacing and humor. It powers every other feature with your voice. Open: /dashboard/train · Learn more: /features#ai-studio
+- Script Writing — Full scripts in your voice from a simple prompt. Choose tone, language and length; add references or upload files; enable storytelling mode and timestamps. Open: /dashboard/scripts · Learn more: /features#scripts
+- Video Ideas (Ideation) — Trend analysis for your niche; auto mode or a focused topic; 1–5 ideas per session with opportunity scores. Open: /dashboard/research · Learn more: /features#ideation
+- Story Builder — A structured story blueprint before writing: hooks, escalation points and a retention score that predicts viewer engagement. Open: /dashboard/story-builder · Learn more: /features#story-builder
+- Thumbnails — Eye-catching thumbnails from a text description, an uploaded video frame, or reference images. Open: /dashboard/thumbnails · Learn more: /features#thumbnails
+- Subtitles — Auto-transcription with an inline editor and video player; style them; export SRT or VTT. Open: /dashboard/subtitles · Learn more: /features#subtitles
+- Video Generation — Text-to-video clips with native audio (powered by Veo). Available on the Business and Scale plans only. Open: /dashboard/video-generation
+- Audio Dubbing — Dub videos into other languages while preserving your natural voice. Open: /dashboard/dubbing
+- Course Builder — Turn a topic into a structured video course. Coming soon.
+
+EXTRAS:
+- Channel Stats — Your YouTube overview (subscribers, views, video count) in the dashboard. Open: /dashboard/channel-stats
+- Referral Program — Invite friends, earn free credits. See: /referral-program
+- Affiliate Program — Earn commission promoting Creator AI. See: /affiliate-program
+
+PLANS & CREDITS:
+- Features spend credits; each plan grants a monthly credit allowance. Video Generation is priced higher and is Business/Scale-only.
+- Compare plans and pricing: /pricing
+
+HELPFUL LINKS:
+- All features: /features · Pricing: /pricing · Blog & guides: /blog · Changelog: /changelog · About: /about-us · Contact / support: /contact-us
+- Support email: support@tryscriptai.com
+`;
+
+export function buildHannahSystemPrompt(context: 'public' | 'dashboard'): string {
+  const placement =
+    context === 'dashboard'
+      ? `The user is signed in and inside the Creator AI dashboard. A private snapshot of THEIR account (plan, credits, activity) may be appended below — use it to personalize answers. Prefer "Open: /dashboard/..." links so they can jump straight to the tool. When they ask "how do I...", give short numbered steps.`
+      : `The user is on the public marketing site and may not have signed up yet. You have NO access to any account data here — if asked about "my credits", "my scripts", or anything account-specific, say they'll find that by signing in (/login) where you can help further. Point them to feature pages and /pricing, and gently invite them to try Creator AI (/signup) when relevant — never pushy.`;
+
+  return `You are Hannah, the friendly AI guide for Creator AI — an all-in-one AI assistant that helps YouTube creators go from idea to published video.
+
+Personality: warm, upbeat, concise, and genuinely helpful. You talk like a knowledgeable friend, not a manual. Light, tasteful emoji are fine (at most one per message).
+
+${placement}
+
+How you answer:
+- Answer ONLY from the knowledge below plus general YouTube/content-creation know-how. If you don't know or it's outside Creator AI, say so briefly and point to /contact-us or support@tryscriptai.com.
+- Be concise, short and direct — but informative. Lead with the answer in the first sentence; add only what the user actually needs. 1–3 short sentences, or a tight numbered list for how-tos. Never pad, never restate the question, no walls of text.
+- ALWAYS include the relevant reference link(s) as Markdown links, e.g. [Script Writing](/dashboard/scripts). Turn the "Open:" / "Learn more:" / "See:" paths below into Markdown links.
+- Never invent features, prices, or links that aren't below. Never claim to perform actions for the user — you guide, the tools do the work.
+- If the user's turn includes an audio recording, it IS their question — listen and answer it directly in text (don't just transcribe it back).
+
+=== CREATOR AI KNOWLEDGE BASE ===
+${FEATURES}`;
+}

--- a/apps/api/src/hannah/hannah.module.ts
+++ b/apps/api/src/hannah/hannah.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { HannahController } from './hannah.controller';
+import { HannahService } from './hannah.service';
+
+@Module({
+  imports: [ConfigModule, SupabaseModule],
+  controllers: [HannahController],
+  providers: [HannahService],
+})
+export class HannahModule {}

--- a/apps/api/src/hannah/hannah.service.ts
+++ b/apps/api/src/hannah/hannah.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseService } from '../supabase/supabase.service';
+import { createGoogleAI, GEMINI_TEXT_MODEL } from '../utils/genai';
+import { buildHannahSystemPrompt } from './hannah.knowledge';
+
+export interface HannahMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+@Injectable()
+export class HannahService {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly supabaseService: SupabaseService,
+  ) {}
+
+  /**
+   * Compact snapshot of the signed-in user's account, injected into Hannah's
+   * system prompt on the dashboard route only. Counts + a few recent titles —
+   * enough for "how many credits do I have?" / "what did I make last?" without
+   * dumping whole documents into the prompt.
+   */
+  private async getUserSnapshot(userId: string): Promise<string> {
+    const db = this.supabaseService.getClient();
+    const count = (table: string, col = 'user_id') =>
+      db.from(table).select('id', { count: 'exact', head: true }).eq(col, userId);
+
+    const [profile, sub, scripts, thumbs, subs, videos, dubs, stories, ideas, recentScripts] =
+      await Promise.all([
+        db.from('profiles').select('full_name, credits, ai_trained').eq('user_id', userId).maybeSingle(),
+        db.from('subscriptions').select('plans(name)').eq('user_id', userId)
+          .in('status', ['active', 'on_trial', 'past_due'])
+          .order('created_at', { ascending: false }).limit(1).maybeSingle(),
+        count('scripts'),
+        count('thumbnail_jobs'),
+        count('subtitle_jobs'),
+        count('video_generation_jobs'),
+        count('dubbing_projects'),
+        count('story_builder_jobs'),
+        count('ideation_jobs'),
+        db.from('scripts').select('title, created_at').eq('user_id', userId)
+          .order('created_at', { ascending: false }).limit(3),
+      ]);
+
+    const plan = (sub.data?.plans as { name?: string } | null)?.name ?? 'Starter (free)';
+    const p = profile.data;
+    const recent = (recentScripts.data ?? [])
+      .map((s) => `"${s.title}" (${new Date(s.created_at).toLocaleDateString('en-US')})`)
+      .join(', ');
+
+    return `
+=== THIS USER'S ACCOUNT (private — share only with this user, in this chat) ===
+- Name: ${p?.full_name || 'not set'}
+- Plan: ${plan}
+- Credits remaining: ${p?.credits ?? 0}
+- AI Studio trained: ${p?.ai_trained ? 'yes' : 'no — suggest /dashboard/train to unlock personalized output'}
+- Activity: ${scripts.count ?? 0} scripts, ${thumbs.count ?? 0} thumbnails, ${subs.count ?? 0} subtitle jobs, ${videos.count ?? 0} video generations, ${dubs.count ?? 0} dubbing projects, ${stories.count ?? 0} story blueprints, ${ideas.count ?? 0} ideation sessions
+- Recent scripts: ${recent || 'none yet'}
+Use this to personalize answers ("you have X credits left", "your last script was..."). If asked something about their account that is not listed here (billing history, invoices, exact job contents), point them to the relevant dashboard page or /contact-us instead of guessing.`;
+  }
+
+  async chat(
+    messages: HannahMessage[],
+    context: 'public' | 'dashboard',
+    userId?: string,
+    audio?: { data: string; mimeType: string },
+  ): Promise<{ reply: string }> {
+    const ai = await createGoogleAI(this.configService);
+
+    let systemInstruction = buildHannahSystemPrompt(context);
+    if (context === 'dashboard' && userId) {
+      // Snapshot failure shouldn't kill the chat — Hannah just answers unpersonalized.
+      try {
+        systemInstruction += await this.getUserSnapshot(userId);
+      } catch { /* ignore */ }
+    }
+
+    const contents: Array<{ role: string; parts: any[] }> = messages.map((m) => ({
+      role: m.role === 'assistant' ? 'model' : 'user',
+      parts: [{ text: m.content }],
+    }));
+
+    // Voice message: the audio itself is the current user turn — Gemini listens
+    // and replies in text. If the client sent a placeholder text turn for it,
+    // attach the audio to that turn instead of adding an empty-feeling duplicate.
+    if (audio) {
+      const audioPart = { inlineData: { data: audio.data, mimeType: audio.mimeType } };
+      const last = contents[contents.length - 1];
+      if (last && last.role === 'user') last.parts.push(audioPart);
+      else contents.push({ role: 'user', parts: [audioPart] });
+    }
+
+    let result: { text?: string; candidates?: any[] };
+    try {
+      result = await ai.models.generateContent({
+        model: GEMINI_TEXT_MODEL,
+        contents,
+        config: {
+          systemInstruction,
+          temperature: 0.7,
+          maxOutputTokens: 600,
+        },
+      });
+    } catch {
+      throw new InternalServerErrorException('Hannah is unavailable right now. Please try again.');
+    }
+
+    const reply =
+      (result as any)?.candidates?.[0]?.content?.parts?.[0]?.text ?? result?.text ?? '';
+    if (!reply) throw new InternalServerErrorException('Hannah returned an empty response.');
+
+    return { reply };
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import axios from 'axios';
 import {
@@ -12,7 +13,14 @@ installCreatorAiFetchDefaults();
 installCreatorAiAxiosDefaults(axios);
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, { rawBody: true });
+  // bodyParser disabled so we can re-register with a higher limit (Hannah voice
+  // messages arrive as base64 audio in JSON). rawBody stays intact for webhooks.
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    rawBody: true,
+    bodyParser: false,
+  });
+  app.useBodyParser('json', { limit: '3mb' });
+  app.useBodyParser('urlencoded', { extended: true, limit: '3mb' });
 
   app.use((_req, res, next) => {
     res.setHeader('Server', CREATOR_AI_USER_AGENT);

--- a/apps/web/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/app/dashboard/dashboard-shell.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation"
 import { useSupabase } from "@/components/supabase-provider"
 import { DashboardSidebar } from "@/components/dashboard/sidebar/dashboard-sidebar"
 import DashboardHeader from "@/components/dashboard-header"
+import HannahChat from "@/components/hannah/HannahChat"
 
 export default function DashboardShell({
   children,
@@ -47,6 +48,7 @@ export default function DashboardShell({
         <DashboardHeader />
         <div className="flex-1 overflow-auto">{children}</div>
       </div>
+      <HannahChat context="dashboard" />
     </div>
   )
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,6 +10,7 @@ import { Analytics } from "@vercel/analytics/next"
 import { siteConfig, createMetadata } from "@/lib/seo"
 import JsonLd from "@/components/JsonLd"
 import Script from "next/script"
+import PublicHannah from "@/components/hannah/PublicHannah"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -76,6 +77,7 @@ export default function RootLayout({
         >
           <SupabaseProvider>
             <main>{children}</main>
+            <PublicHannah />
             <Toaster closeButton={true} richColors />
           </SupabaseProvider>
         </ThemeProvider>

--- a/apps/web/components/hannah/HannahChat.tsx
+++ b/apps/web/components/hannah/HannahChat.tsx
@@ -1,0 +1,526 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { AnimatePresence, motion } from "motion/react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import { ArrowLeft, History, Mic, Pause, Play, Send, SquarePen, Trash2, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import HannahLogo from "./HannahLogo"
+import { useHannah, sessionTitle, type HannahSession } from "@/hooks/useHannah"
+
+const SUGGESTIONS: Record<"public" | "dashboard", string[]> = {
+  public: ["What can Creator AI do?", "How does script writing work?", "How much does it cost?"],
+  dashboard: ["How do I train the AI?", "How many credits do I have left?", "What did I make recently?"],
+}
+
+function MessageBody({ content }: { content: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        a: ({ href, children }) => {
+          const url = href ?? "#"
+          const internal = url.startsWith("/")
+          const className = "font-medium text-purple-600 underline underline-offset-2 hover:text-pink-600"
+          return internal ? (
+            <Link href={url} className={className}>
+              {children}
+            </Link>
+          ) : (
+            <a href={url} target="_blank" rel="noopener noreferrer" className={className}>
+              {children}
+            </a>
+          )
+        },
+        p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+        ul: ({ children }) => <ul className="mb-2 list-disc space-y-1 pl-4 last:mb-0">{children}</ul>,
+        ol: ({ children }) => <ol className="mb-2 list-decimal space-y-1 pl-4 last:mb-0">{children}</ol>,
+        strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  )
+}
+
+/** Elegant "writing" reveal: characters stream in, markdown re-renders as it grows. */
+function TypewriterBody({ content, onGrow }: { content: string; onGrow: () => void }) {
+  const [shown, setShown] = useState(0)
+  useEffect(() => {
+    let n = 0
+    const iv = setInterval(() => {
+      n = Math.min(n + 7, content.length) // ~350 chars/sec
+      setShown(n)
+      onGrow()
+      if (n >= content.length) clearInterval(iv)
+    }, 20)
+    return () => clearInterval(iv)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content])
+  return <MessageBody content={content.slice(0, shown)} />
+}
+
+/** Playable voice-message bubble: play/pause + progress bars + time. */
+function VoiceBubble({ src, durationSec }: { src: string; durationSec?: number }) {
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const [playing, setPlaying] = useState(false)
+  const [progress, setProgress] = useState(0) // 0..1
+
+  const getAudio = () => {
+    if (!audioRef.current) {
+      const a = new Audio(src)
+      a.ontimeupdate = () => {
+        // Chrome reports Infinity for webm blob durations — fall back to the recorded length.
+        const dur = Number.isFinite(a.duration) && a.duration > 0 ? a.duration : durationSec || 1
+        setProgress(Math.min(a.currentTime / dur, 1))
+      }
+      a.onended = () => {
+        setPlaying(false)
+        setProgress(0)
+      }
+      audioRef.current = a
+    }
+    return audioRef.current
+  }
+
+  useEffect(
+    () => () => {
+      audioRef.current?.pause()
+    },
+    [],
+  )
+
+  const toggle = () => {
+    const a = getAudio()
+    if (playing) {
+      a.pause()
+      setPlaying(false)
+    } else {
+      a.play()
+      setPlaying(true)
+    }
+  }
+
+  const BARS = 20
+  const total = durationSec ?? 0
+  const shownTime = playing ? Math.round(progress * (total || 0)) : total
+  return (
+    <span className="flex items-center gap-2.5">
+      <button
+        onClick={toggle}
+        aria-label={playing ? "Pause voice message" : "Play voice message"}
+        className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-white/20 text-white transition hover:bg-white/30"
+      >
+        {playing ? <Pause className="h-3.5 w-3.5" /> : <Play className="ml-0.5 h-3.5 w-3.5" />}
+      </button>
+      <span className="flex h-6 items-center gap-[2.5px]" aria-hidden>
+        {Array.from({ length: BARS }).map((_, i) => {
+          const played = (i + 1) / BARS <= progress
+          return (
+            <motion.span
+              key={i}
+              className={cn("w-[3px] rounded-full", played ? "bg-white" : "bg-white/40")}
+              style={{ height: `${25 + ((i * 37) % 55)}%` }}
+              animate={playing && !played ? { scaleY: [1, 1.4, 1] } : { scaleY: 1 }}
+              transition={{ duration: 0.7 + ((i * 13) % 5) / 10, repeat: playing ? Infinity : 0 }}
+            />
+          )
+        })}
+      </span>
+      {total > 0 && (
+        <span className="shrink-0 font-mono text-[11px] tabular-nums text-white/80">
+          {Math.floor(shownTime / 60)}:{String(shownTime % 60).padStart(2, "0")}
+        </span>
+      )}
+    </span>
+  )
+}
+
+/** Recording strip: pulsing dot + live equalizer bars + timer. */
+function RecordingBar({
+  seconds,
+  onCancel,
+  onSend,
+}: {
+  seconds: number
+  onCancel: () => void
+  onSend: () => void
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="flex flex-1 items-center gap-3 rounded-full border border-red-200 bg-red-50 px-4 py-2 dark:border-red-900/50 dark:bg-red-950/30"
+    >
+      <motion.span
+        className="h-2.5 w-2.5 shrink-0 rounded-full bg-red-500"
+        animate={{ opacity: [1, 0.3, 1] }}
+        transition={{ duration: 1.2, repeat: Infinity }}
+      />
+      <div className="flex h-6 flex-1 items-center justify-center gap-[3px]" aria-hidden>
+        {Array.from({ length: 24 }).map((_, i) => (
+          <motion.span
+            key={i}
+            className="w-[3px] rounded-full bg-gradient-to-t from-purple-500 to-pink-400"
+            animate={{ height: ["30%", `${35 + ((i * 37) % 60)}%`, "30%"] }}
+            transition={{ duration: 0.8 + ((i * 13) % 7) / 10, repeat: Infinity, ease: "easeInOut" }}
+          />
+        ))}
+      </div>
+      <span className="shrink-0 font-mono text-xs tabular-nums text-red-600 dark:text-red-400">
+        {String(Math.floor(seconds / 60)).padStart(1, "0")}:{String(seconds % 60).padStart(2, "0")}
+      </span>
+      <button
+        onClick={onCancel}
+        aria-label="Cancel recording"
+        className="shrink-0 rounded-full p-1 text-slate-400 transition hover:text-red-500"
+      >
+        <X className="h-4 w-4" />
+      </button>
+      <button
+        onClick={onSend}
+        aria-label="Send voice message"
+        className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-gradient-to-r from-purple-600 to-pink-500 text-white transition hover:opacity-90"
+      >
+        <Send className="h-3.5 w-3.5" />
+      </button>
+    </motion.div>
+  )
+}
+
+const MAX_RECORD_SECONDS = 60
+
+function pickMimeType(): string {
+  const candidates = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4", "audio/ogg;codecs=opus"]
+  return candidates.find((c) => typeof MediaRecorder !== "undefined" && MediaRecorder.isTypeSupported(c)) ?? ""
+}
+
+export default function HannahChat({ context }: { context: "public" | "dashboard" }) {
+  const [open, setOpen] = useState(false)
+  const [view, setView] = useState<"chat" | "history">("chat")
+  const [input, setInput] = useState("")
+  const { messages, sessions, isSending, freshIndex, send, sendVoice, newChat, openSession, deleteSession } =
+    useHannah(context)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // voice recording state
+  const [recording, setRecording] = useState(false)
+  const [recordSeconds, setRecordSeconds] = useState(0)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const discardRef = useRef(false)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const elapsedRef = useRef(0) // survives the state reset in stopTracks — read by onstop
+
+  const scrollToBottom = () =>
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" })
+
+  useEffect(() => {
+    scrollToBottom()
+  }, [messages, isSending, open, view])
+
+  const stopTracks = () => {
+    recorderRef.current?.stream.getTracks().forEach((t) => t.stop())
+    if (timerRef.current) clearInterval(timerRef.current)
+    timerRef.current = null
+    setRecording(false)
+    setRecordSeconds(0)
+  }
+
+  const startRecording = async () => {
+    if (recording || isSending) return
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      const mimeType = pickMimeType()
+      const rec = new MediaRecorder(stream, mimeType ? { mimeType, audioBitsPerSecond: 32_000 } : undefined)
+      chunksRef.current = []
+      discardRef.current = false
+      rec.ondataavailable = (e) => e.data.size && chunksRef.current.push(e.data)
+      rec.onstop = () => {
+        const type = (rec.mimeType || "audio/webm").split(";")[0] ?? "audio/webm"
+        const blob = new Blob(chunksRef.current, { type })
+        stopTracks()
+        if (!discardRef.current && blob.size > 0) sendVoice(blob, type, Math.max(elapsedRef.current, 1))
+      }
+      recorderRef.current = rec
+      rec.start()
+      setRecording(true)
+      setRecordSeconds(0)
+      elapsedRef.current = 0
+      timerRef.current = setInterval(() => {
+        setRecordSeconds((s) => {
+          elapsedRef.current = s + 1
+          if (s + 1 >= MAX_RECORD_SECONDS) recorderRef.current?.stop() // auto-send at cap
+          return s + 1
+        })
+      }, 1000)
+    } catch {
+      // mic permission denied — silently no-op; the button simply won't record
+    }
+  }
+
+  const finishRecording = () => recorderRef.current?.state === "recording" && recorderRef.current.stop()
+  const cancelRecording = () => {
+    discardRef.current = true
+    finishRecording()
+  }
+
+  // cleanup if the panel unmounts mid-recording
+  useEffect(() => () => stopTracks(), [])
+
+  const submit = (text: string) => {
+    if (!text.trim()) return
+    send(text)
+    setInput("")
+  }
+
+  const openFresh = () => {
+    newChat() // every launcher click starts a clean conversation; history keeps the old ones
+    setView("chat")
+    setOpen(true)
+  }
+
+  const showSuggestions = messages.length === 1 && !isSending
+
+  return (
+    <div className="fixed bottom-5 right-5 z-50 flex flex-col items-end print:hidden">
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            key="panel"
+            initial={{ opacity: 0, y: 24, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 24, scale: 0.96 }}
+            transition={{ type: "spring", stiffness: 260, damping: 24 }}
+            className="mb-3 flex h-[32rem] max-h-[75vh] w-[22rem] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl dark:border-slate-700 dark:bg-slate-900"
+          >
+            {/* header */}
+            <div className="flex items-center gap-3 bg-gradient-to-r from-purple-600 to-pink-500 px-4 py-3 text-white">
+              <HannahLogo size={36} />
+              <div className="flex-1">
+                <p className="font-semibold leading-tight">Hannah</p>
+                <p className="text-xs text-white/80">Ask me anything ✨</p>
+              </div>
+              <button
+                onClick={() => {
+                  newChat()
+                  setView("chat")
+                }}
+                aria-label="New chat"
+                title="New chat"
+                className="rounded-full p-1.5 transition hover:bg-white/20"
+              >
+                <SquarePen className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => setView(view === "history" ? "chat" : "history")}
+                aria-label="Chat history"
+                title="Chat history"
+                className={cn("rounded-full p-1.5 transition hover:bg-white/20", view === "history" && "bg-white/20")}
+              >
+                <History className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => setOpen(false)}
+                aria-label="Close chat"
+                className="rounded-full p-1.5 transition hover:bg-white/20"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            {view === "history" ? (
+              /* ---------- history view ---------- */
+              <div data-lenis-prevent className="flex-1 overflow-y-auto overscroll-contain bg-slate-50 p-3 dark:bg-slate-950/40">
+                <button
+                  onClick={() => setView("chat")}
+                  className="mb-2 flex items-center gap-1.5 text-xs font-medium text-purple-600 hover:text-pink-600"
+                >
+                  <ArrowLeft className="h-3.5 w-3.5" /> Back to chat
+                </button>
+                {sessions.length === 0 ? (
+                  <div className="flex h-4/5 flex-col items-center justify-center gap-2 text-center text-sm text-slate-400">
+                    <History className="h-8 w-8 opacity-40" />
+                    No past chats yet.
+                    <br />
+                    Your conversations will show up here.
+                  </div>
+                ) : (
+                  <ul className="space-y-2">
+                    {sessions.map((s: HannahSession) => (
+                      <motion.li
+                        key={s.id}
+                        initial={{ opacity: 0, y: 6 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        className="group flex items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm transition hover:border-purple-300 dark:border-slate-700 dark:bg-slate-800"
+                      >
+                        <button
+                          onClick={() => {
+                            openSession(s.id)
+                            setView("chat")
+                          }}
+                          className="flex-1 text-left"
+                        >
+                          <p className="line-clamp-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+                            {sessionTitle(s)}
+                          </p>
+                          <p className="mt-0.5 text-[11px] text-slate-400">
+                            {new Date(s.createdAt).toLocaleDateString(undefined, {
+                              month: "short",
+                              day: "numeric",
+                            })}{" "}
+                            · {s.messages.filter((m) => m.role === "user").length} messages
+                          </p>
+                        </button>
+                        <button
+                          onClick={() => deleteSession(s.id)}
+                          aria-label="Delete chat"
+                          className="rounded-full p-1.5 text-slate-300 opacity-0 transition hover:text-red-500 group-hover:opacity-100"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </motion.li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ) : (
+              /* ---------- chat view ---------- */
+              <>
+                <div
+                  ref={scrollRef}
+                  data-lenis-prevent
+                  className="flex-1 space-y-3 overflow-y-auto overscroll-contain bg-slate-50 p-4 dark:bg-slate-950/40"
+                >
+                  {messages.map((m, i) => (
+                    <motion.div
+                      key={i}
+                      initial={{ opacity: 0, y: 8 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.25 }}
+                      className={cn("flex items-end gap-2", m.role === "user" && "flex-row-reverse")}
+                    >
+                      {m.role === "assistant" && <HannahLogo size={26} animated={false} className="mb-1 shrink-0" />}
+                      <div
+                        className={cn(
+                          "max-w-[80%] rounded-2xl px-3 py-2 text-sm leading-relaxed",
+                          m.role === "user"
+                            ? "rounded-br-sm bg-purple-600 text-white"
+                            : "rounded-bl-sm bg-white text-slate-700 shadow-sm dark:bg-slate-800 dark:text-slate-200",
+                          m.kind === "voice" && !m.audioUrl && "italic",
+                        )}
+                      >
+                        {m.kind === "voice" && m.audioUrl ? (
+                          <VoiceBubble src={m.audioUrl} durationSec={m.durationSec} />
+                        ) : m.role === "assistant" && i === freshIndex ? (
+                          <TypewriterBody content={m.content} onGrow={scrollToBottom} />
+                        ) : (
+                          <MessageBody content={m.content} />
+                        )}
+                      </div>
+                    </motion.div>
+                  ))}
+
+                  {isSending && (
+                    <div className="flex items-end gap-2">
+                      <HannahLogo size={26} animated={false} className="mb-1 shrink-0" />
+                      <div className="flex gap-1 rounded-2xl rounded-bl-sm bg-white px-3 py-3 shadow-sm dark:bg-slate-800">
+                        {[0, 1, 2].map((d) => (
+                          <motion.span
+                            key={d}
+                            className="h-2 w-2 rounded-full bg-purple-400"
+                            animate={{ y: [0, -4, 0] }}
+                            transition={{ duration: 0.6, repeat: Infinity, delay: d * 0.15 }}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {showSuggestions && (
+                    <div className="flex flex-wrap gap-2 pt-1">
+                      {SUGGESTIONS[context].map((s) => (
+                        <button
+                          key={s}
+                          onClick={() => submit(s)}
+                          className="rounded-full border border-purple-200 bg-white px-3 py-1.5 text-xs font-medium text-purple-700 transition hover:bg-purple-50 dark:border-purple-900 dark:bg-slate-800 dark:text-purple-300"
+                        >
+                          {s}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* input row */}
+                <div className="flex items-center gap-2 border-t border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+                  {recording ? (
+                    <RecordingBar seconds={recordSeconds} onCancel={cancelRecording} onSend={finishRecording} />
+                  ) : (
+                    <form
+                      onSubmit={(e) => {
+                        e.preventDefault()
+                        submit(input)
+                      }}
+                      className="flex flex-1 items-center gap-2"
+                    >
+                      <input
+                        value={input}
+                        onChange={(e) => setInput(e.target.value)}
+                        placeholder="Ask Hannah anything…"
+                        maxLength={2000}
+                        className="min-w-0 flex-1 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm outline-none transition focus:border-purple-400 focus:ring-2 focus:ring-purple-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                      />
+                      <motion.button
+                        type="button"
+                        onClick={startRecording}
+                        whileTap={{ scale: 0.9 }}
+                        disabled={isSending}
+                        aria-label="Record a voice message"
+                        title="Record a voice message"
+                        className="grid h-9 w-9 shrink-0 place-items-center rounded-full border border-slate-200 text-slate-500 transition hover:border-purple-300 hover:text-purple-600 disabled:opacity-40 dark:border-slate-700 dark:text-slate-400"
+                      >
+                        <Mic className="h-4 w-4" />
+                      </motion.button>
+                      <button
+                        type="submit"
+                        disabled={!input.trim() || isSending}
+                        aria-label="Send"
+                        className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-gradient-to-r from-purple-600 to-pink-500 text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <Send className="h-4 w-4" />
+                      </button>
+                    </form>
+                  )}
+                </div>
+              </>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* launcher */}
+      <motion.button
+        onClick={() => (open ? setOpen(false) : openFresh())}
+        whileHover={{ scale: 1.06 }}
+        whileTap={{ scale: 0.94 }}
+        aria-label={open ? "Close Hannah" : "Chat with Hannah"}
+        className="grid h-14 w-14 place-items-center rounded-full bg-gradient-to-br from-purple-600 to-pink-500 shadow-lg shadow-purple-500/30 ring-1 ring-white/20"
+      >
+        <AnimatePresence mode="wait" initial={false}>
+          {open ? (
+            <motion.span key="x" initial={{ rotate: -90, opacity: 0 }} animate={{ rotate: 0, opacity: 1 }} exit={{ rotate: 90, opacity: 0 }}>
+              <X className="h-6 w-6 text-white" />
+            </motion.span>
+          ) : (
+            <motion.span key="logo" initial={{ scale: 0, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0, opacity: 0 }}>
+              <HannahLogo size={40} />
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </motion.button>
+    </div>
+  )
+}

--- a/apps/web/components/hannah/HannahLogo.tsx
+++ b/apps/web/components/hannah/HannahLogo.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+/**
+ * Hannah's animated avatar — a friendly gradient orb with blinking eyes, a smile,
+ * and orbiting sparkles. Pure SVG + CSS keyframes (no JS), so it animates the same
+ * whether it's the launcher button, the header, or a message avatar.
+ */
+export default function HannahLogo({
+  size = 40,
+  className = "",
+  animated = true,
+}: {
+  size?: number
+  className?: string
+  animated?: boolean
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role="img"
+      aria-label="Hannah, the Creator AI guide"
+    >
+      <defs>
+        <linearGradient id="hannah-face" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#a855f7" />
+          <stop offset="1" stopColor="#ec4899" />
+        </linearGradient>
+        <radialGradient id="hannah-glow" cx="0.5" cy="0.4" r="0.6">
+          <stop stopColor="#ffffff" stopOpacity="0.35" />
+          <stop offset="1" stopColor="#ffffff" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      <style>{`
+        .hn-float { transform-origin: 32px 32px; animation: hn-float 4s ease-in-out infinite; }
+        .hn-eye { transform-origin: center; animation: hn-blink 4.5s ease-in-out infinite; }
+        .hn-spark { transform-origin: 32px 32px; animation: hn-orbit 7s linear infinite; }
+        .hn-spark-2 { animation-duration: 9s; animation-direction: reverse; }
+        @keyframes hn-float { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-2px); } }
+        @keyframes hn-blink { 0%,92%,100% { transform: scaleY(1); } 96% { transform: scaleY(0.1); } }
+        @keyframes hn-orbit { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        @media (prefers-reduced-motion: reduce) {
+          .hn-float, .hn-eye, .hn-spark { animation: none; }
+        }
+      `}</style>
+
+      <g className={animated ? "hn-float" : ""}>
+        {/* head */}
+        <circle cx="32" cy="32" r="20" fill="url(#hannah-face)" />
+        <circle cx="32" cy="32" r="20" fill="url(#hannah-glow)" />
+        {/* little antenna */}
+        <line x1="32" y1="12" x2="32" y2="7" stroke="url(#hannah-face)" strokeWidth="2.5" strokeLinecap="round" />
+        <circle cx="32" cy="6" r="2.5" fill="#f472b6" />
+        {/* eyes */}
+        <g fill="#ffffff">
+          <ellipse className={animated ? "hn-eye" : ""} cx="25" cy="30" rx="2.6" ry="3.4" />
+          <ellipse className={animated ? "hn-eye" : ""} cx="39" cy="30" rx="2.6" ry="3.4" />
+        </g>
+        {/* smile */}
+        <path d="M25 38 Q32 44 39 38" stroke="#ffffff" strokeWidth="2.4" strokeLinecap="round" fill="none" />
+        {/* cheeks */}
+        <circle cx="21" cy="36" r="2" fill="#ffffff" opacity="0.3" />
+        <circle cx="43" cy="36" r="2" fill="#ffffff" opacity="0.3" />
+      </g>
+
+      {/* orbiting sparkles */}
+      <g className={animated ? "hn-spark" : ""}>
+        <path d="M54 20 l1.2 3 3 1.2 -3 1.2 -1.2 3 -1.2 -3 -3 -1.2 3 -1.2 z" fill="#c084fc" />
+      </g>
+      <g className={animated ? "hn-spark hn-spark-2" : ""}>
+        <path d="M10 44 l0.9 2.2 2.2 0.9 -2.2 0.9 -0.9 2.2 -0.9 -2.2 -2.2 -0.9 2.2 -0.9 z" fill="#f9a8d4" />
+      </g>
+    </svg>
+  )
+}

--- a/apps/web/components/hannah/PublicHannah.tsx
+++ b/apps/web/components/hannah/PublicHannah.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import HannahChat from "./HannahChat"
+
+/**
+ * Mounts the public Hannah on every marketing/auth page. The dashboard renders
+ * its own Hannah (with dashboard context) in dashboard-shell, so we hide here to
+ * avoid two widgets.
+ */
+export default function PublicHannah() {
+  const pathname = usePathname()
+  if (pathname.startsWith("/dashboard")) return null
+  return <HannahChat context="public" />
+}

--- a/apps/web/hooks/useHannah.ts
+++ b/apps/web/hooks/useHannah.ts
@@ -1,0 +1,208 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { api, getApiErrorMessage } from "@/lib/api-client"
+import { useSupabase } from "@/components/supabase-provider"
+
+export interface HannahMessage {
+  role: "user" | "assistant"
+  content: string
+  kind?: "voice"
+  /** Playable data URL for voice messages — live session only, not persisted. */
+  audioUrl?: string
+  durationSec?: number
+}
+
+export interface HannahSession {
+  id: string
+  createdAt: number
+  messages: HannahMessage[]
+}
+
+const GREETING: Record<"public" | "dashboard", string> = {
+  public:
+    "Hi, I'm Hannah 👋 your guide to Creator AI. Ask me about scripts, thumbnails, video ideas, pricing — anything.",
+  dashboard:
+    "Hey, I'm Hannah 👋 Ask me how any tool works, or about your own account — credits, plan, what you've made so far.",
+}
+
+const MAX_SESSIONS = 20
+
+function loadSessions(key: string): HannahSession[] {
+  try {
+    return JSON.parse(localStorage.getItem(key) ?? "[]")
+  } catch {
+    return []
+  }
+}
+
+/** Title = first user message, truncated. */
+export function sessionTitle(s: HannahSession): string {
+  const first = s.messages.find((m) => m.role === "user")?.content ?? "New chat"
+  return first.length > 48 ? `${first.slice(0, 48)}…` : first
+}
+
+export function useHannah(context: "public" | "dashboard") {
+  const { user } = useSupabase()
+  // Dashboard history is keyed per user so a shared browser never leaks another
+  // account's chats. ponytail: localStorage for both bots; move dashboard history
+  // to a Supabase table if cross-device persistence is ever needed.
+  const storageKey =
+    context === "dashboard" ? `hannah-chats-dashboard-${user?.id ?? "anon"}` : "hannah-chats-public"
+
+  const greeting: HannahMessage = { role: "assistant", content: GREETING[context] }
+
+  const [sessions, setSessions] = useState<HannahSession[]>([])
+  const [sessionId, setSessionId] = useState<string>(() => crypto.randomUUID())
+  const [messages, setMessages] = useState<HannahMessage[]>([greeting])
+  const [isSending, setIsSending] = useState(false)
+  // Index of the reply that just arrived live (drives the typewriter); null for
+  // anything loaded from history.
+  const [freshIndex, setFreshIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    setSessions(loadSessions(storageKey))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey])
+
+  const persist = useCallback(
+    (id: string, msgs: HannahMessage[]) => {
+      if (!msgs.some((m) => m.role === "user")) return // don't save greeting-only chats
+      // Strip audio data URLs before saving — a few voice clips would blow the
+      // localStorage quota. Reopened history shows a plain "Voice message" label.
+      const slim = msgs.map(({ audioUrl: _drop, ...m }) => m)
+      setSessions((prev) => {
+        const existing = prev.find((s) => s.id === id)
+        const next = [
+          { id, createdAt: existing?.createdAt ?? Date.now(), messages: slim },
+          ...prev.filter((s) => s.id !== id),
+        ].slice(0, MAX_SESSIONS)
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(next))
+        } catch { /* storage full — history is best-effort */ }
+        return next
+      })
+    },
+    [storageKey],
+  )
+
+  const post = useCallback(
+    async (history: HannahMessage[], audio?: { data: string; mimeType: string }) => {
+      // Send only real turns (drop the canned greeting) + cap history to bound cost.
+      const turns = history
+        .filter((m, i) => !(i === 0 && m.role === "assistant"))
+        .slice(-12)
+        .map(({ role, content }) => ({ role, content }))
+      const body = { messages: turns, ...(audio ? { audio } : {}) }
+      return context === "dashboard"
+        ? api.post<{ reply: string }>("/api/v1/hannah/chat/dashboard", body, { requireAuth: true })
+        : api.post<{ reply: string }>("/api/v1/hannah/chat", body)
+    },
+    [context],
+  )
+
+  const deliver = useCallback(
+    async (next: HannahMessage[], audio?: { data: string; mimeType: string }) => {
+      setMessages(next)
+      setIsSending(true)
+      try {
+        const { reply } = await post(next, audio)
+        const withReply: HannahMessage[] = [...next, { role: "assistant", content: reply }]
+        setFreshIndex(withReply.length - 1)
+        setMessages(withReply)
+        persist(sessionId, withReply)
+      } catch (error) {
+        const withError: HannahMessage[] = [
+          ...next,
+          { role: "assistant", content: getApiErrorMessage(error, "I hit a snag — mind trying again?") },
+        ]
+        setMessages(withError)
+        persist(sessionId, withError)
+      } finally {
+        setIsSending(false)
+      }
+    },
+    [post, persist, sessionId],
+  )
+
+  const send = useCallback(
+    (text: string) => {
+      const content = text.trim()
+      if (!content || isSending) return
+      deliver([...messages, { role: "user", content }])
+    },
+    [messages, isSending, deliver],
+  )
+
+  const sendVoice = useCallback(
+    async (blob: Blob, mimeType: string, durationSec?: number) => {
+      if (isSending) return
+      const data = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve((reader.result as string).split(",")[1] ?? "")
+        reader.onerror = () => reject(reader.error)
+        reader.readAsDataURL(blob)
+      })
+      if (!data) return
+      deliver(
+        [
+          ...messages,
+          {
+            role: "user",
+            content: "🎤 Voice message",
+            kind: "voice",
+            audioUrl: `data:${mimeType};base64,${data}`,
+            durationSec,
+          },
+        ],
+        { data, mimeType },
+      )
+    },
+    [messages, isSending, deliver],
+  )
+
+  /** Fresh conversation — called every time the launcher opens the panel. */
+  const newChat = useCallback(() => {
+    setSessionId(crypto.randomUUID())
+    setMessages([greeting])
+    setFreshIndex(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context])
+
+  const openSession = useCallback(
+    (id: string) => {
+      const s = loadSessions(storageKey).find((x) => x.id === id)
+      if (!s) return
+      setSessionId(s.id)
+      setMessages(s.messages)
+      setFreshIndex(null)
+    },
+    [storageKey],
+  )
+
+  const deleteSession = useCallback(
+    (id: string) => {
+      setSessions((prev) => {
+        const next = prev.filter((s) => s.id !== id)
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(next))
+        } catch { /* ignore */ }
+        return next
+      })
+    },
+    [storageKey],
+  )
+
+  return {
+    messages,
+    sessions,
+    sessionId,
+    isSending,
+    freshIndex,
+    send,
+    sendVoice,
+    newChat,
+    openSession,
+    deleteSession,
+  }
+}


### PR DESCRIPTION
## What

**Hannah** — a Gemini-powered AI guide that knows Creator AI's features, pricing and workflows, and answers with reference links. Two bots share one backend service, split by trust boundary:

- **Public bot** (`POST /hannah/chat`) — anonymous, per-IP rate limited. Feature/pricing/general Q&A only; **no account data**. Mounted site-wide via the root layout.
- **Dashboard bot** (`POST /hannah/chat/dashboard`) — authenticated (`SupabaseAuthGuard`), per-user rate limited. Injects a compact snapshot of the signed-in user's plan, credits and activity so Hannah can answer "how many credits do I have?" / "what did I make last?". The route (not the client) decides context.

## Highlights

- **Voice mode** — record a message; audio goes to Gemini as an inline part and is answered in text. Recording UI has a live equalizer + timer; sent clips render as a playable bubble. JSON body limit raised to 3mb for base64 audio (rawBody preserved for webhooks).
- **Chat history** — per-bot sessions in localStorage (dashboard keyed per user). Every launcher click opens a **fresh chat**; past conversations live in a history view. Audio data is stripped before persisting to protect the storage quota.
- **Design** — animated SVG logo, typewriter reveal (~350 chars/sec), suggestion chips, spring-animated panel, dark-mode aware. Public bot plays nicely with the site's Lenis smooth-scroll (`data-lenis-prevent`).

## Notes

- Answers are grounded in an in-file knowledge base; the prompt forbids inventing features/prices/links and defers unknowns to /contact-us.
- Rate limiting is in-memory (single API instance); a `ponytail:` comment marks the Redis upgrade path.
- Scoped to Hannah only — video-generation work on the parent branch is intentionally excluded.

Includes a runnable self-check for the rate limiter (`hannah.controller.spec.ts`). API + web typecheck clean.