### PR TITLE
feat(admin): manage user membership plans and full profile from dashboard

### DIFF
--- a/apps/api/src/admin/admin.controller.ts
+++ b/apps/api/src/admin/admin.controller.ts
@@ -61,11 +61,30 @@ export class AdminController {
     );
   }
 
+  @Get('plans')
+  @ApiOperation({ summary: 'Active membership plans (for admin assignment)' })
+  getPlans() {
+    return this.adminService.getPlans();
+  }
+
   @Get('users/:userId')
   @ApiOperation({ summary: 'Get user by id' })
   @ApiParam({ name: 'userId' })
   getUser(@Param('userId') userId: string) {
     return this.adminService.getUser(userId);
+  }
+
+  @Put('users/:userId/plan')
+  @ApiOperation({ summary: 'Set a user membership plan and grant its credits' })
+  @ApiParam({ name: 'userId' })
+  @ApiBody({ schema: { type: 'object', required: ['planId'], properties: { planId: { type: 'string' } } } })
+  setUserPlan(
+    @Param('userId') userId: string,
+    @Body() body: { planId: string },
+    @Req() req: AuthRequest,
+  ) {
+    this.adminService.logActivity(this.getUserId(req), 'set_user_plan', 'user', userId, body);
+    return this.adminService.setUserPlan(userId, body.planId);
   }
 
   @Put('users/:userId')

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -73,22 +73,165 @@ export class AdminService {
     const { data, error, count } = await query;
     if (error) throw new BadRequestException(error.message);
 
-    return { data, total: count ?? 0, page, limit };
+    // subscriptions.user_id has no FK to profiles, so PostgREST can't embed it.
+    // Fetch active subscriptions separately and join in JS — same pattern as the
+    // affiliate admin queries. (subscriptions.plan_id -> plans FK does resolve.)
+    const userIds = [...new Set((data ?? []).map((u) => u.user_id))];
+    const { data: subs } = userIds.length
+      ? await this.db
+          .from('subscriptions')
+          .select('user_id, plan_id, plans(id, name, credits_monthly)')
+          .in('user_id', userIds)
+          .eq('status', 'active')
+      : { data: [] };
+    const planByUser = new Map<string, { plan_id: string; plans: unknown }>(
+      (subs ?? []).map((s) => [s.user_id as string, s as { plan_id: string; plans: unknown }]),
+    );
+
+    const withPlan = (data ?? []).map((u) => {
+      const sub = planByUser.get(u.user_id);
+      return { ...u, plan: sub?.plans ?? null, plan_id: sub?.plan_id ?? null };
+    });
+
+    return { data: withPlan, total: count ?? 0, page, limit };
   }
+
+  async getPlans() {
+    const { data, error } = await this.db
+      .from('plans')
+      .select('id, name, price_monthly, credits_monthly')
+      .eq('is_active', true)
+      .order('price_monthly', { ascending: true });
+
+    if (error) throw new BadRequestException(error.message);
+    return data ?? [];
+  }
+
+  /**
+   * Manually set a user's membership plan and grant that plan's credit allowance.
+   * Mirrors the billing free-plan flow: cancel active subs, insert a fresh active
+   * row. ponytail: admin-granted override — Lemon Squeezy is NOT touched, so a user
+   * on a real paid subscription keeps getting billed there. Cancel in LS separately
+   * if that's intended.
+   */
+  async setUserPlan(userId: string, planId: string) {
+    const { data: plan, error: planErr } = await this.db
+      .from('plans')
+      .select('id, credits_monthly')
+      .eq('id', planId)
+      .single();
+    if (planErr || !plan) throw new NotFoundException('Plan not found');
+
+    await this.db
+      .from('subscriptions')
+      .update({ status: 'canceled' })
+      .eq('user_id', userId)
+      .in('status', ['active', 'on_trial', 'past_due']);
+
+    const now = new Date().toISOString();
+    const { data: newSub, error: subErr } = await this.db
+      .from('subscriptions')
+      .insert({
+        user_id: userId,
+        plan_id: planId,
+        ls_subscription_id: null,
+        ls_customer_id: null,
+        ls_order_id: null,
+        status: 'active',
+        billing_interval: 'monthly',
+        credits_last_refreshed_at: now,
+        current_period_start: now,
+        current_period_end: null,
+      })
+      .select('*, plans(*)')
+      .single();
+    if (subErr) throw new BadRequestException(subErr.message);
+
+    const { data: profile, error: credErr } = await this.db
+      .from('profiles')
+      .update({ credits: plan.credits_monthly })
+      .eq('user_id', userId)
+      .select()
+      .single();
+    if (credErr) throw new BadRequestException(credErr.message);
+
+    return { success: true, credits: plan.credits_monthly, subscription: newSub, profile };
+  }
+
+  // Feature tables that record per-user credit usage — same set billing uses for
+  // usage history. Each has user_id, created_at and credits_consumed.
+  private static readonly ACTIVITY_TABLES: Record<string, string> = {
+    scripts: 'Script',
+    ideation_jobs: 'Ideation',
+    thumbnail_jobs: 'Thumbnail',
+    subtitle_jobs: 'Subtitle',
+    dubbing_projects: 'Dubbing',
+    story_builder_jobs: 'Story Builder',
+    documentation_generations: 'Documentation',
+    video_generation_jobs: 'Video Generation',
+  };
+
+  // Never expose password-reset OTP columns to the admin UI.
+  private static readonly PROFILE_SECRET_FIELDS = [
+    'password_reset_otp',
+    'password_reset_otp_expires_at',
+    'password_reset_otp_attempts',
+    'password_reset_otp_verified',
+  ];
 
   async getUser(userId: string) {
     const { data, error } = await this.db
       .from('profiles')
-      .select('*, subscriptions(*), usage_credits(*)')
+      .select('*')
       .eq('user_id', userId)
       .single();
 
     if (error || !data) throw new NotFoundException('User not found');
-    return data;
+
+    for (const f of AdminService.PROFILE_SECRET_FIELDS) delete (data as Record<string, unknown>)[f];
+
+    // subscriptions / usage_credits / youtube_channels have no FK to profiles, so
+    // they can't be embedded — fetch them separately by user_id.
+    const [{ data: subscriptions }, { data: usage_credits }, { data: channels }] = await Promise.all([
+      this.db.from('subscriptions').select('*, plans(*)').eq('user_id', userId).order('created_at', { ascending: false }),
+      this.db.from('usage_credits').select('*').eq('user_id', userId),
+      this.db.from('youtube_channels').select('*').eq('user_id', userId),
+    ]);
+
+    const activity = await this.getUserActivity(userId);
+
+    return {
+      ...data,
+      subscriptions: subscriptions ?? [],
+      usage_credits: usage_credits ?? [],
+      channels: channels ?? [],
+      activity,
+    };
+  }
+
+  private async getUserActivity(userId: string, perTable = 10) {
+    const entries = Object.entries(AdminService.ACTIVITY_TABLES);
+    const results = await Promise.all(
+      entries.map(async ([table, label]) => {
+        const { data } = await this.db
+          .from(table)
+          .select('id, created_at, credits_consumed')
+          .eq('user_id', userId)
+          .order('created_at', { ascending: false })
+          .limit(perTable);
+        return (data ?? []).map((r) => ({ ...r, feature: label }));
+      }),
+    );
+
+    return results
+      .flat()
+      .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
+      .slice(0, 30);
   }
 
   private static readonly ALLOWED_USER_FIELDS = new Set([
-    'full_name', 'name', 'email', 'credits', 'role', 'avatar_url',
+    'full_name', 'name', 'email', 'bio', 'credits', 'role', 'avatar_url',
+    'ai_trained', 'youtube_connected', 'language', 'referral_code', 'referred_by',
   ]);
 
   async updateUser(userId: string, updates: Record<string, unknown>) {

--- a/apps/web/app/dashboard/admin/users/[userId]/page.tsx
+++ b/apps/web/app/dashboard/admin/users/[userId]/page.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { useRouter, useParams } from "next/navigation"
+import { adminApi } from "@/hooks/useAdmin"
+import { ArrowLeft, Edit, Youtube, Shield } from "lucide-react"
+import { AdminButton } from "@/components/admin/admin-button"
+import { UserEditDialog } from "@/components/admin/user-edit-dialog"
+
+type Row = Record<string, unknown>
+
+function Field({ label, value }: { label: string; value: unknown }) {
+  const display =
+    value === null || value === undefined || value === ""
+      ? "—"
+      : typeof value === "boolean"
+        ? value ? "Yes" : "No"
+        : String(value)
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-slate-500">{label}</dt>
+      <dd className="text-sm text-slate-200 mt-0.5 break-words">{display}</dd>
+    </div>
+  )
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+      <h2 className="text-sm font-semibold text-slate-300 mb-4">{title}</h2>
+      {children}
+    </div>
+  )
+}
+
+export default function AdminUserDetailPage() {
+  const router = useRouter()
+  const params = useParams()
+  const userId = params.userId as string
+
+  const [user, setUser] = useState<Row | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState(false)
+  const [plans, setPlans] = useState<Array<{ id: string; name: string; credits_monthly: number }>>([])
+
+  const fetchUser = useCallback(async () => {
+    setLoading(true)
+    try {
+      setUser(await adminApi.getUser(userId))
+    } catch {
+      setUser(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [userId])
+
+  useEffect(() => { fetchUser() }, [fetchUser])
+  useEffect(() => { adminApi.getPlans().then(setPlans).catch(() => {}) }, [])
+
+  if (loading) {
+    return <div className="h-40 rounded-xl bg-slate-800/50 animate-pulse" />
+  }
+  if (!user) {
+    return (
+      <div className="space-y-4">
+        <AdminButton variant="tertiary" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4 mr-1" /> Back
+        </AdminButton>
+        <p className="text-slate-400">User not found.</p>
+      </div>
+    )
+  }
+
+  const subscriptions = (user.subscriptions as Row[]) ?? []
+  const channels = (user.channels as Row[]) ?? []
+  const activity = (user.activity as Row[]) ?? []
+  const usageCredits = (user.usage_credits as Row[]) ?? []
+  const activeSub = subscriptions.find((s) => s.status === "active") ?? null
+  const activePlan = activeSub?.plans as { name?: string } | undefined
+
+  // Feed the edit dialog the flat plan_id the list rows carry.
+  const editUser: Row = { ...user, plan_id: activeSub?.plan_id ?? null }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <AdminButton variant="tertiary" size="icon" onClick={() => router.back()}>
+            <ArrowLeft className="h-4 w-4" />
+          </AdminButton>
+          <div>
+            <h1 className="text-2xl font-bold text-slate-100 flex items-center gap-2">
+              {(user.full_name || user.name || "Unnamed user") as string}
+              {user.role === "admin" && (
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-900/40 text-purple-400">
+                  <Shield className="h-3 w-3" /> admin
+                </span>
+              )}
+            </h1>
+            <p className="text-slate-400 text-sm mt-0.5">{user.email as string}</p>
+          </div>
+        </div>
+        <AdminButton variant="primary" onClick={() => setEditing(true)}>
+          <Edit className="h-4 w-4 mr-1" /> Edit
+        </AdminButton>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Card title="Membership & credits">
+          <dl className="grid grid-cols-2 gap-4">
+            <Field label="Current plan" value={activePlan?.name ?? "Free"} />
+            <Field label="Credits" value={user.credits} />
+            <Field label="Billing interval" value={activeSub?.billing_interval} />
+            <Field label="Status" value={activeSub?.status} />
+            <Field label="Period start" value={fmtDate(activeSub?.current_period_start)} />
+            <Field label="Renews / ends" value={fmtDate(activeSub?.current_period_end)} />
+          </dl>
+        </Card>
+
+        <Card title="Identity">
+          <dl className="grid grid-cols-2 gap-4">
+            <Field label="Full name" value={user.full_name} />
+            <Field label="Display name" value={user.name} />
+            <Field label="Language" value={user.language} />
+            <Field label="AI trained" value={user.ai_trained} />
+            <Field label="YouTube connected" value={user.youtube_connected} />
+            <Field label="Referral code" value={user.referral_code} />
+            <Field label="Referred by" value={user.referred_by} />
+            <Field label="Total referrals" value={user.total_referrals} />
+            <Field label="Joined" value={fmtDate(user.created_at)} />
+            <div className="col-span-2">
+              <Field label="Bio" value={user.bio} />
+            </div>
+          </dl>
+        </Card>
+      </div>
+
+      {channels.length > 0 && (
+        <Card title="Connected channels">
+          <div className="space-y-3">
+            {channels.map((c) => (
+              <div key={c.id as string} className="flex items-center gap-3">
+                <Youtube className="h-5 w-5 text-red-500 shrink-0" />
+                <div className="min-w-0">
+                  <p className="text-sm text-slate-200 truncate">{(c.channel_name ?? c.channel_id) as string}</p>
+                  <p className="text-xs text-slate-500">
+                    {fmtNum(c.subscriber_count)} subscribers · {fmtNum(c.video_count)} videos
+                    {c.custom_url ? ` · ${c.custom_url}` : ""}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      <Card title="Recent activity">
+        {activity.length === 0 ? (
+          <p className="text-sm text-slate-500">No activity yet.</p>
+        ) : (
+          <div className="divide-y divide-slate-800">
+            {activity.map((a, i) => (
+              <div key={i} className="flex items-center justify-between py-2 text-sm">
+                <span className="text-slate-300">{a.feature as string}</span>
+                <span className="text-slate-500">
+                  {(a.credits_consumed as number) > 0 ? `${a.credits_consumed} credits · ` : ""}
+                  {fmtDate(a.created_at)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      {usageCredits.length > 0 && (
+        <Card title="Usage credit periods">
+          <div className="divide-y divide-slate-800">
+            {usageCredits.map((u) => (
+              <div key={u.id as string} className="flex items-center justify-between py-2 text-sm">
+                <span className="text-slate-500">
+                  {fmtDate(u.period_start)} – {fmtDate(u.period_end)}
+                </span>
+                <span className="text-slate-300">
+                  {u.credits_used as number} used · {u.credits_remaining as number} left
+                </span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {editing && (
+        <UserEditDialog
+          user={editUser}
+          plans={plans}
+          onOpenChange={(open) => setEditing(open)}
+          onSaved={fetchUser}
+        />
+      )}
+    </div>
+  )
+}
+
+function fmtDate(v: unknown): string {
+  if (!v) return "—"
+  const d = new Date(v as string)
+  return isNaN(d.getTime()) ? "—" : d.toLocaleDateString()
+}
+
+function fmtNum(v: unknown): string {
+  const n = Number(v)
+  return isNaN(n) ? "0" : n.toLocaleString()
+}

--- a/apps/web/app/dashboard/admin/users/page.tsx
+++ b/apps/web/app/dashboard/admin/users/page.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
 import { useAdminUsers, adminApi } from "@/hooks/useAdmin"
 import { Search, ChevronLeft, ChevronRight, Trash2, Edit, Shield } from "lucide-react"
 import { AdminButton } from "@/components/admin/admin-button"
+import { UserEditDialog } from "@/components/admin/user-edit-dialog"
 import { Input } from "@repo/ui/input"
 import {
   Select,
@@ -22,6 +24,7 @@ import {
 import { toast } from "sonner"
 
 export default function AdminUsersPage() {
+  const router = useRouter()
   const [page, setPage] = useState(1)
   const [search, setSearch] = useState("")
   const [roleFilter, setRoleFilter] = useState<string>("")
@@ -29,9 +32,12 @@ export default function AdminUsersPage() {
   const { data, total, loading, refresh } = useAdminUsers(page, search, roleFilter)
 
   const [editUser, setEditUser] = useState<Record<string, unknown> | null>(null)
-  const [editRole, setEditRole] = useState("")
-  const [editCredits, setEditCredits] = useState("")
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null)
+  const [plans, setPlans] = useState<Array<{ id: string; name: string; credits_monthly: number }>>([])
+
+  useEffect(() => {
+    adminApi.getPlans().then(setPlans).catch(() => {})
+  }, [])
 
   const totalPages = Math.ceil((total || 0) / 20)
 
@@ -39,21 +45,6 @@ export default function AdminUsersPage() {
     e.preventDefault()
     setSearch(searchInput)
     setPage(1)
-  }
-
-  const handleUpdateUser = async () => {
-    if (!editUser) return
-    try {
-      const updates: Record<string, unknown> = {}
-      if (editRole) updates.role = editRole
-      if (editCredits) updates.credits = Number(editCredits)
-      await adminApi.updateUser(editUser.user_id as string, updates)
-      toast.success("User updated")
-      setEditUser(null)
-      refresh()
-    } catch {
-      toast.error("Failed to update user")
-    }
   }
 
   const handleDelete = async () => {
@@ -110,6 +101,7 @@ export default function AdminUsersPage() {
                 <th className="px-4 py-3 font-medium">Name</th>
                 <th className="px-4 py-3 font-medium">Email</th>
                 <th className="px-4 py-3 font-medium">Role</th>
+                <th className="px-4 py-3 font-medium">Plan</th>
                 <th className="px-4 py-3 font-medium">Credits</th>
                 <th className="px-4 py-3 font-medium">Joined</th>
                 <th className="px-4 py-3 font-medium">Actions</th>
@@ -119,18 +111,22 @@ export default function AdminUsersPage() {
               {loading ? (
                 Array.from({ length: 5 }).map((_, i) => (
                   <tr key={i}>
-                    <td colSpan={6} className="px-4 py-3">
+                    <td colSpan={7} className="px-4 py-3">
                       <div className="h-5 bg-slate-800 rounded animate-pulse" />
                     </td>
                   </tr>
                 ))
               ) : data?.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-slate-500">No users found</td>
+                  <td colSpan={7} className="px-4 py-8 text-center text-slate-500">No users found</td>
                 </tr>
               ) : (
                 data?.map((user: Record<string, unknown>) => (
-                  <tr key={user.user_id as string} className="hover:bg-slate-900/30">
+                  <tr
+                    key={user.user_id as string}
+                    onClick={() => router.push(`/dashboard/admin/users/${user.user_id}`)}
+                    className="hover:bg-slate-900/30 cursor-pointer"
+                  >
                     <td className="px-4 py-3 text-slate-200">{(user.full_name || user.name || "-") as string}</td>
                     <td className="px-4 py-3 text-slate-400">{user.email as string}</td>
                     <td className="px-4 py-3">
@@ -143,14 +139,17 @@ export default function AdminUsersPage() {
                         {user.role as string}
                       </span>
                     </td>
+                    <td className="px-4 py-3 text-slate-300">
+                      {(user.plan as { name?: string } | null)?.name ?? "Free"}
+                    </td>
                     <td className="px-4 py-3 text-slate-300">{user.credits as number}</td>
                     <td className="px-4 py-3 text-slate-500">
                       {new Date(user.created_at as string).toLocaleDateString()}
                     </td>
                     <td className="px-4 py-3">
-                      <div className="flex gap-1">
+                      <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
                         <button
-                          onClick={() => { setEditUser(user); setEditRole(user.role as string); setEditCredits(String(user.credits)); }}
+                          onClick={() => setEditUser(user)}
                           className="p-1.5 rounded hover:bg-slate-800 text-slate-400 hover:text-slate-200"
                         >
                           <Edit className="h-4 w-4" />
@@ -188,45 +187,12 @@ export default function AdminUsersPage() {
         </div>
       )}
 
-      {/* Edit User Dialog */}
-      <Dialog open={!!editUser} onOpenChange={() => setEditUser(null)}>
-        <DialogContent className="bg-slate-900 border-slate-800 text-slate-100">
-          <DialogHeader>
-            <DialogTitle>Edit User</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4 py-4">
-            <div>
-              <label className="text-sm text-slate-400 mb-1 block">Role</label>
-              <Select value={editRole} onValueChange={setEditRole}>
-                <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="bg-slate-800 border-slate-700">
-                  <SelectItem value="user">User</SelectItem>
-                  <SelectItem value="admin">Admin</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <label className="text-sm text-slate-400 mb-1 block">Credits</label>
-              <Input
-                type="number"
-                value={editCredits}
-                onChange={(e) => setEditCredits(e.target.value)}
-                className="bg-slate-800 border-slate-700 text-slate-200"
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <AdminButton variant="tertiary" onClick={() => setEditUser(null)}>
-              Cancel
-            </AdminButton>
-            <AdminButton variant="primary" onClick={handleUpdateUser}>
-              Save
-            </AdminButton>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <UserEditDialog
+        user={editUser}
+        plans={plans}
+        onOpenChange={(open) => { if (!open) setEditUser(null) }}
+        onSaved={refresh}
+      />
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={!!deleteConfirm} onOpenChange={() => setDeleteConfirm(null)}>

--- a/apps/web/components/admin/user-edit-dialog.tsx
+++ b/apps/web/components/admin/user-edit-dialog.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { adminApi } from "@/hooks/useAdmin"
+import { AdminButton } from "@/components/admin/admin-button"
+import { Input } from "@repo/ui/input"
+import { Textarea } from "@repo/ui/textarea"
+import { Switch } from "@repo/ui/switch"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/select"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@repo/ui/dialog"
+import { toast } from "sonner"
+
+type Plan = { id: string; name: string; credits_monthly: number }
+
+// Profile fields the admin can edit. Mirrors ALLOWED_USER_FIELDS on the API.
+const TEXT_FIELDS: Array<{ key: string; label: string; type?: string }> = [
+  { key: "full_name", label: "Full name" },
+  { key: "name", label: "Display name" },
+  { key: "email", label: "Email", type: "email" },
+  { key: "avatar_url", label: "Avatar URL" },
+  { key: "language", label: "Language" },
+  { key: "referral_code", label: "Referral code" },
+  { key: "referred_by", label: "Referred by" },
+]
+
+export function UserEditDialog({
+  user,
+  plans,
+  onOpenChange,
+  onSaved,
+}: {
+  user: Record<string, unknown> | null
+  plans: Plan[]
+  onOpenChange: (open: boolean) => void
+  onSaved: () => void
+}) {
+  const [form, setForm] = useState<Record<string, unknown>>({})
+  const [planId, setPlanId] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    setForm({
+      full_name: user.full_name ?? "",
+      name: user.name ?? "",
+      email: user.email ?? "",
+      avatar_url: user.avatar_url ?? "",
+      bio: user.bio ?? "",
+      language: user.language ?? "",
+      referral_code: user.referral_code ?? "",
+      referred_by: user.referred_by ?? "",
+      role: (user.role as string) ?? "user",
+      credits: user.credits ?? 0,
+      ai_trained: !!user.ai_trained,
+      youtube_connected: !!user.youtube_connected,
+    })
+    setPlanId((user.plan_id as string) ?? "")
+  }, [user])
+
+  const set = (k: string, v: unknown) => setForm((f) => ({ ...f, [k]: v }))
+
+  const save = async () => {
+    if (!user) return
+    setSaving(true)
+    try {
+      // Plan first — this grants the plan's credit allowance — then the profile
+      // fields, so any manual credits override wins.
+      if (planId && planId !== ((user.plan_id as string) ?? "")) {
+        await adminApi.setUserPlan(user.user_id as string, planId)
+      }
+      await adminApi.updateUser(user.user_id as string, {
+        ...form,
+        credits: Number(form.credits),
+      })
+      toast.success("User updated")
+      onOpenChange(false)
+      onSaved()
+    } catch {
+      toast.error("Failed to update user")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={!!user} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-800 text-slate-100 max-w-2xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Edit User</DialogTitle>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 py-4">
+          {TEXT_FIELDS.map((f) => (
+            <div key={f.key}>
+              <label className="text-sm text-slate-400 mb-1 block">{f.label}</label>
+              <Input
+                type={f.type ?? "text"}
+                value={(form[f.key] as string) ?? ""}
+                onChange={(e) => set(f.key, e.target.value)}
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
+            </div>
+          ))}
+
+          <div>
+            <label className="text-sm text-slate-400 mb-1 block">Role</label>
+            <Select value={form.role as string} onValueChange={(v) => set("role", v)}>
+              <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="bg-slate-800 border-slate-700">
+                <SelectItem value="user">User</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label className="text-sm text-slate-400 mb-1 block">Plan</label>
+            <Select
+              value={planId}
+              onValueChange={(v) => {
+                setPlanId(v)
+                const p = plans.find((pl) => pl.id === v)
+                if (p) set("credits", p.credits_monthly)
+              }}
+            >
+              <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
+                <SelectValue placeholder="Select plan" />
+              </SelectTrigger>
+              <SelectContent className="bg-slate-800 border-slate-700">
+                {plans.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label className="text-sm text-slate-400 mb-1 block">Credits</label>
+            <Input
+              type="number"
+              value={String(form.credits ?? "")}
+              onChange={(e) => set("credits", e.target.value)}
+              className="bg-slate-800 border-slate-700 text-slate-200"
+            />
+          </div>
+
+          <div className="sm:col-span-2">
+            <label className="text-sm text-slate-400 mb-1 block">Bio</label>
+            <Textarea
+              value={(form.bio as string) ?? ""}
+              onChange={(e) => set("bio", e.target.value)}
+              className="bg-slate-800 border-slate-700 text-slate-200"
+            />
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-slate-800 px-3 py-2">
+            <span className="text-sm text-slate-300">AI trained</span>
+            <Switch checked={!!form.ai_trained} onCheckedChange={(v) => set("ai_trained", v)} />
+          </div>
+          <div className="flex items-center justify-between rounded-lg border border-slate-800 px-3 py-2">
+            <span className="text-sm text-slate-300">YouTube connected</span>
+            <Switch checked={!!form.youtube_connected} onCheckedChange={(v) => set("youtube_connected", v)} />
+          </div>
+        </div>
+
+        <p className="text-xs text-slate-500 -mt-2">Changing the plan grants its credit allowance and resets the subscription (billing provider is not affected).</p>
+
+        <DialogFooter>
+          <AdminButton variant="tertiary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </AdminButton>
+          <AdminButton variant="primary" onClick={save} disabled={saving}>
+            {saving ? "Saving..." : "Save"}
+          </AdminButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/hooks/useAdmin.ts
+++ b/apps/web/hooks/useAdmin.ts
@@ -258,6 +258,12 @@ export const adminApi = {
     api.put(`/api/v1/admin/users/${userId}`, updates, AUTH),
   deleteUser: (userId: string) =>
     api.delete(`/api/v1/admin/users/${userId}`, AUTH),
+  getPlans: () =>
+    api.get<Array<{ id: string; name: string; price_monthly: number; credits_monthly: number }>>('/api/v1/admin/plans', AUTH),
+  getUser: (userId: string) =>
+    api.get<Record<string, unknown>>(`/api/v1/admin/users/${userId}`, AUTH),
+  setUserPlan: (userId: string, planId: string) =>
+    api.put(`/api/v1/admin/users/${userId}/plan`, { planId }, AUTH),
   createBlog: (data: Partial<BlogPost>) =>
     api.post<BlogPost>('/api/v1/admin/blogs', data, AUTH),
   updateBlog: (id: string, data: Partial<BlogPost>) =>


### PR DESCRIPTION
## What

Admins can now manage any user's membership plan and full profile directly from the dashboard Users section.

### 1. Change plan → credits + subscription update together
New `setUserPlan` cancels the user's active subscriptions and inserts a fresh active one (with `billing_interval`, `credits_last_refreshed_at`, `current_period_start`), and grants the plan's credit allowance. Changing a plan now updates credits and subscription details in one action.

### 2. User detail page
Clicking any row opens a per-user page showing membership & credits, full identity, connected YouTube channels, recent cross-feature activity, and usage-credit periods.

### 3. Full editable profile
The edit dialog now exposes every editable profile field (name, display name, email, avatar, language, referral code / referred-by, bio, role, plan, credits, and the `ai_trained` / `youtube_connected` toggles). Extracted into a shared `UserEditDialog` reused by the list and the detail page.

## Fixes along the way
`subscriptions`, `usage_credits`, and `youtube_channels` have no foreign key to `profiles`, so PostgREST can't embed them — the original `getUsers`/`getUser` embeds threw *"Could not find a relationship."* Now fetched and joined in JS (same pattern the affiliate admin queries already use). `getUser` also strips `password_reset_otp*` columns.

## Notes
- Admin plan changes are a manual override and intentionally do **not** touch Lemon Squeezy — a user on a real paid subscription keeps billing there (marked with a `ponytail:` comment). Cancel in LS separately if intended.
- `email` edits write the `profiles` column only, not Supabase auth.

## Test plan
- Open a user row → detail page loads with activity feed + channel.
- Edit → change plan → credits and the membership card update.
- API and web typecheck clean.