### PR TITLE
fix(web): wrap useSearchParams pages in Suspense so next build succeeds

### DIFF
--- a/apps/web/app/dashboard/admin/emails/send/page.tsx
+++ b/apps/web/app/dashboard/admin/emails/send/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback, useRef, useMemo } from "react"
+import { useState, useEffect, useCallback, useRef, useMemo, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import {
   adminApi,
@@ -48,7 +48,16 @@ const DEMO_RECIPIENT: RecipientRecord = {
 
 type Snapshot = { html: string; subject: string }
 
+// useSearchParams must sit inside a Suspense boundary or `next build` fails.
 export default function ComposeCampaignPage() {
+  return (
+    <Suspense fallback={<div className="h-64 rounded-xl bg-slate-800/50 animate-pulse" />}>
+      <ComposeCampaignInner />
+    </Suspense>
+  )
+}
+
+function ComposeCampaignInner() {
   const router = useRouter()
   const preselect = useSearchParams().get("template")
 

--- a/apps/web/app/unsubscribe/page.tsx
+++ b/apps/web/app/unsubscribe/page.tsx
@@ -1,12 +1,22 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, Suspense } from "react"
 import { useSearchParams } from "next/navigation"
 import Image from "next/image"
 
 type State = "confirm" | "loading" | "done" | "error" | "invalid"
 
+// useSearchParams must sit inside a Suspense boundary or `next build` fails when
+// it tries to prerender this public route.
 export default function UnsubscribePage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-[#0f0a29]" />}>
+      <UnsubscribeInner />
+    </Suspense>
+  )
+}
+
+function UnsubscribeInner() {
   const userId = useSearchParams().get("u")
   const [state, setState] = useState<State>("confirm")
 


### PR DESCRIPTION
## Problem

The production Lightsail deploy (`docker compose -f docker-compose.prod.yml build`) was failing at `web#build` (`Dockerfile.web:13 → turbo run build --filter=web`).

Root cause: the new public `/unsubscribe` route and the campaign compose page call `useSearchParams()` directly. That passes `tsc --noEmit` and `next dev`, but **production `next build` errors** with *"useSearchParams() should be wrapped in a suspense boundary"* while prerendering the page — so the web image never rebuilds and prod keeps serving the old container.

## Fix

Wrap both pages' `useSearchParams` usage in a `<Suspense>` boundary, matching the existing convention in `app/error/page.tsx` and `app/careers/apply/page.tsx`.

## Verification

`turbo run build --filter=web` now compiles and generates **all 69 static pages** (including `/unsubscribe`) — the exact step that was failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)