### PR TITLE
perf(web): first-load cleanups + hero fixes + drop dead Vercel analytics

### DIFF
--- a/apps/web/app/about-us/page.tsx
+++ b/apps/web/app/about-us/page.tsx
@@ -345,7 +345,7 @@ export default function AboutPage() {
               </p>
             </motion.div>
 
-            <motion.div
+            <motion.ul
               className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto"
               initial="hidden"
               whileInView="show"
@@ -355,7 +355,7 @@ export default function AboutPage() {
               {features.map((feature) => {
                 const Icon = feature.icon
                 return (
-                  <motion.div
+                  <motion.li
                     key={feature.title}
                     variants={{
                       hidden: { opacity: 0, y: 30 },
@@ -368,10 +368,10 @@ export default function AboutPage() {
                       icon={<Icon className="h-6 w-6 text-slate-500" />}
                       description={feature.description}
                     />
-                  </motion.div>
+                  </motion.li>
                 )
               })}
-            </motion.div>
+            </motion.ul>
           </div>
         </section>
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -109,8 +109,20 @@ export default function RootLayout({
             gtag('config', 'G-RVSYKESCPC');
           `}
         </Script>
-        <SpeedInsights />
-        <Analytics />
+        {/* Vercel serves these two scripts from /_vercel/* on its own edge, so
+            on the self-hosted box (Caddy -> Next standalone) they fall through
+            to the 404 page and every visitor's console logs a MIME-type refusal
+            for a script that cannot exist there. `VERCEL` is set to "1" only
+            when Vercel is actually running the app, so the Vercel-served
+            deployment keeps full analytics while the self-hosted one stops
+            asking. Needs "Enable access to System Environment Variables" left
+            on in project settings (Vercel's default). */}
+        {process.env.VERCEL && (
+          <>
+            <SpeedInsights />
+            <Analytics />
+          </>
+        )}
       </body>
     </html>
   )

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,6 +10,7 @@ import JsonLd from "@/components/JsonLd";
 import Script from "next/script";
 import PublicHannah from "@/components/hannah/PublicHannah"
 import MotionProvider from "@/components/MotionProvider"
+import WebVitals from "@/components/WebVitals"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -66,6 +67,8 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
+        {/* Client boundary is confined to this one null-rendering component. */}
+        <WebVitals />
         <JsonLd data={organizationJsonLd} />
         <JsonLd data={webAppJsonLd} />
         <ThemeProvider

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,9 +4,7 @@ import { Inter } from "next/font/google";
 import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@repo/ui/sonner";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import { SupabaseProvider } from "@/components/supabase-provider";
-import { Analytics } from "@vercel/analytics/next";
 import { siteConfig, createMetadata } from "@/lib/seo";
 import JsonLd from "@/components/JsonLd";
 import Script from "next/script";
@@ -109,20 +107,6 @@ export default function RootLayout({
             gtag('config', 'G-RVSYKESCPC');
           `}
         </Script>
-        {/* Vercel serves these two scripts from /_vercel/* on its own edge, so
-            on the self-hosted box (Caddy -> Next standalone) they fall through
-            to the 404 page and every visitor's console logs a MIME-type refusal
-            for a script that cannot exist there. `VERCEL` is set to "1" only
-            when Vercel is actually running the app, so the Vercel-served
-            deployment keeps full analytics while the self-hosted one stops
-            asking. Needs "Enable access to System Environment Variables" left
-            on in project settings (Vercel's default). */}
-        {process.env.VERCEL && (
-          <>
-            <SpeedInsights />
-            <Analytics />
-          </>
-        )}
       </body>
     </html>
   )

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -59,7 +59,7 @@ export default function Home() {
             />
           </div>
 
-          <div className="container mx-12 px-6 grid grid-cols-1 md:grid-cols-2 gap-8 items-center relative z-10">
+          <div className="container px-6 grid grid-cols-1 md:grid-cols-2 gap-8 items-center relative z-10">
             <div className="flex flex-col items-center md:items-start text-center md:text-left">
               <div
                 className={`${RISE} inline-flex items-center gap-2 px-4 py-1 mb-4 rounded-full text-sm font-medium bg-white/60 ring-1 ring-slate-900/10 backdrop-blur-md`}

--- a/apps/web/components/WebVitals.tsx
+++ b/apps/web/components/WebVitals.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useReportWebVitals } from "next/web-vitals"
+
+/**
+ * Reports Core Web Vitals to GA4.
+ *
+ * Google ranks on field data (CrUX), not on the lab numbers PageSpeed shows, and
+ * INP — the metric that replaced FID — only exists in the field: no lab run can
+ * measure how a real user's interactions felt. Without this the site collects
+ * none of it.
+ *
+ * Values are queued straight onto dataLayer rather than through `window.gtag`.
+ * gtag.js loads with strategy="lazyOnload", so FCP and LCP have normally already
+ * fired before the global exists; dataLayer is a replay queue, so GA4 picks these
+ * up when it initialises instead of dropping them.
+ */
+function reportWebVital(metric: { name: string; value: number; id: string }) {
+  const w = window as unknown as { dataLayer?: unknown[] }
+  const dataLayer = (w.dataLayer ??= [])
+
+  dataLayer.push([
+    "event",
+    metric.name,
+    {
+      // GA4 metric values must be integers, and CLS is a small fraction.
+      value: Math.round(metric.name === "CLS" ? metric.value * 1000 : metric.value),
+      // Unique per page load, so percentiles can be rebuilt in GA4.
+      event_label: metric.id,
+      // Keeps these off bounce-rate calculations.
+      non_interaction: true,
+    },
+  ])
+}
+
+export default function WebVitals() {
+  useReportWebVitals(reportWebVital)
+  return null
+}

--- a/apps/web/components/feature-card.tsx
+++ b/apps/web/components/feature-card.tsx
@@ -9,7 +9,10 @@ interface FeatureCardProps {
 
 const FeatureCard: React.FC<FeatureCardProps> = ({ icon, title, description }) => {
   return (
-    <li className="min-h-[14rem] list-none focus-within:ring-2 focus-within:ring-purple-500 rounded-3xl transition">
+    // The list semantics live on the caller's <li> wrapper: a <ul> may only
+    // directly contain <li>, and every caller wraps this card in an animated
+    // element, so the card itself stays a plain div.
+    <div className="min-h-[14rem] focus-within:ring-2 focus-within:ring-purple-500 rounded-3xl transition">
       <div className="relative h-full rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 shadow-sm transition-all duration-300 hover:shadow-xl hover:shadow-purple-500/10 dark:hover:shadow-purple-400/5 hover:scale-[1.02]">
         <GlowingEffect
           spread={40}
@@ -35,7 +38,7 @@ const FeatureCard: React.FC<FeatureCardProps> = ({ icon, title, description }) =
           </div>
         </div>
       </div>
-    </li>
+    </div>
   );
 };
 

--- a/apps/web/components/issue/report-an-issue.tsx
+++ b/apps/web/components/issue/report-an-issue.tsx
@@ -42,14 +42,26 @@ const ReportIssue = ({ useIcon }: { useIcon: boolean }) => {
   return (
     <Popover>
       <PopoverTrigger asChild>
+        {/* Both branches must be real buttons. `asChild` hands the trigger's
+            button semantics (type, aria-haspopup/expanded/controls) to whatever
+            child is here — on a <p> or <div> those ARIA attributes aren't valid
+            for the element's role, and neither is focusable, so the popover was
+            unreachable by keyboard entirely. */}
         {useIcon ? (
-          <div className="fixed bottom-4 right-4 z-50 w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 bg-[#8e8c8c] rounded-full flex items-center justify-center cursor-pointer shadow-md transition-transform hover:scale-105">
+          <button
+            type="button"
+            aria-label="Report an issue"
+            className="fixed bottom-4 right-4 z-50 w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 bg-[#8e8c8c] rounded-full flex items-center justify-center cursor-pointer shadow-md transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2"
+          >
             <IconBugFilled className="text-black w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14" />
-          </div>
+          </button>
         ) : (
-          <p className="text-sm text-slate-600 dark:text-slate-400 dark:hover:text-slate-100 transition-colors hover:text-purple-500 cursor-pointer">
+          <button
+            type="button"
+            className="text-sm text-slate-600 dark:text-slate-400 dark:hover:text-slate-100 transition-colors hover:text-purple-500 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 rounded"
+          >
             Report an Issue
-          </p>
+          </button>
         )}
       </PopoverTrigger>
 

--- a/apps/web/components/landingPage/FeatureSection.tsx
+++ b/apps/web/components/landingPage/FeatureSection.tsx
@@ -116,7 +116,10 @@ export default function FeatureSection() {
         </p>
       </motion.div>
 
-      <motion.div
+      {/* A real <ul>/<li>: screen readers then announce "list, 11 items" and let
+          users step through the features. Tailwind's preflight already strips the
+          markers, so nothing changes visually. */}
+      <motion.ul
         className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-12"
         variants={containerVariants}
         initial="hidden"
@@ -126,7 +129,7 @@ export default function FeatureSection() {
         {features.map((feature, index) => {
           const Icon = feature.icon
           return (
-            <motion.div
+            <motion.li
               key={index}
               variants={itemVariants}
               transition={{ type: "spring", stiffness: 100, damping: 14 }}
@@ -136,10 +139,10 @@ export default function FeatureSection() {
                 icon={<Icon className="h-6 w-6 text-purple-600 dark:text-purple-400" />}
                 description={feature.description}
               />
-            </motion.div>
+            </motion.li>
           )
         })}
-      </motion.div>
+      </motion.ul>
     </div>
   )
 }

--- a/apps/web/components/landingPage/LandingPageSVG.tsx
+++ b/apps/web/components/landingPage/LandingPageSVG.tsx
@@ -98,12 +98,20 @@ const LandingPageSVG = () => {
                             animate={{ strokeDashoffset: [20, 0] }}
                             transition={{ repeat: Infinity, duration: 6, ease: "linear" }}
                         />
+                        {/* Pulses with `scale`, not the `r` attribute. MotionProvider
+                            loads its feature bundle asynchronously, so until it lands
+                            `m.circle` can't resolve an `r` keyframe array and writes
+                            r="undefined" — an SVG error in the console. Same pulse the
+                            sparks below use, and a transform composites instead of
+                            forcing layout every frame. fill-box keeps it centred; SVG
+                            would otherwise scale from the user-space origin. */}
                         <motion.circle
                             cx="60"
                             cy="60"
                             r="1"
                             fill="white"
-                            animate={{ r: [1, 2, 1], opacity: [0.3, 0.8, 0.3] }}
+                            style={{ transformBox: "fill-box", transformOrigin: "center" }}
+                            animate={{ scale: [1, 2, 1], opacity: [0.3, 0.8, 0.3] }}
                             transition={{ duration: 2.5, repeat: Infinity }}
                         />
                     </svg>

--- a/apps/web/components/landingPage/PricingSection.tsx
+++ b/apps/web/components/landingPage/PricingSection.tsx
@@ -59,6 +59,10 @@ export default function PricingSection({ hideHeader = false }: { hideHeader?: bo
                 <button
                     type="button"
                     role="switch"
+                    // Stable name: the ARIA spec requires a switch's label not to
+                    // change with its state. "Annual billing" + aria-checked reads
+                    // as on/off; the flanking Monthly/Annual text is visual only.
+                    aria-label="Annual billing"
                     aria-checked={annual}
                     onClick={() => setAnnual((v) => !v)}
                     className={cn(

--- a/apps/web/components/landingPage/ReviewsMarquee.tsx
+++ b/apps/web/components/landingPage/ReviewsMarquee.tsx
@@ -43,7 +43,7 @@ function ReviewCard({
           height={32}
           loading="lazy"
           alt={`${name}, YouTube creator`}
-          src={img}
+          src={`${img}?size=64`}
         />
         <div className="min-w-0 flex-1">
           <figcaption className="text-sm font-medium text-slate-900 dark:text-white">

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -44,6 +44,13 @@ const nextConfig = {
   // does this for lucide-react, @tabler/icons-react, recharts and date-fns.
   experimental: {
     optimizePackageImports: ["motion", "@repo/ui", "@tsparticles/slim"],
+    // Inline the Tailwind CSS as a <style> tag instead of a render-blocking
+    // <link>, killing the CSS request waterfall that PageSpeed flags (~930ms
+    // mobile). Right feature for App Router — optimizeCss/critters can't stream.
+    // ponytail: experimental + build-only (invisible in `next dev`); verify on
+    // the Vercel preview before merge. Trade-off is returning visitors re-fetch
+    // the ~30KiB CSS per load — negligible for a first-visitor landing page.
+    inlineCss: true,
   },
   // 301s from the original blog slugs to the longer, keyword-rich SEO slugs.
   // Preserves rankings/backlinks after the 2026 SEO slug migration.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -8,6 +8,44 @@ import { dirname, resolve } from 'node:path';
 // absent (Vercel injects env directly) — dotenv silently ignores a missing path.
 config({ path: resolve(dirname(fileURLToPath(import.meta.url)), '../../.env') });
 
+// --- Content Security Policy ------------------------------------------------
+// Built from env so dev (localhost API) and prod (real API host) share one
+// policy instead of two that drift apart.
+//
+// Shipped as Content-Security-Policy-REPORT-ONLY on purpose: it reports
+// violations without blocking, so real traffic proves the allowlist is complete
+// before anything can break. See the note in headers() for the enforce path.
+const isDev = process.env.NODE_ENV === "development";
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ?? "";
+// Supabase realtime uses a websocket on the same host.
+const supabaseWs = supabaseUrl.replace(/^https:/, "wss:");
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  // 'unsafe-inline' is load-bearing while these pages stay static. Nonces are
+  // the strong alternative, but Next can only inject them during dynamic
+  // rendering, which turns off static generation, ISR and CDN caching — the
+  // exact wins the recent perf work bought. inlineCss also emits inline
+  // <style> tags by design.
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://www.googletagmanager.com https://lmsqueezy.com https://app.lemonsqueezy.com`,
+  "style-src 'self' 'unsafe-inline'",
+  `img-src 'self' data: blob: https://avatar.vercel.sh https://yt3.ggpht.com https://i.ytimg.com https://www.google-analytics.com ${supabaseUrl}`,
+  "font-src 'self' data:",
+  `connect-src 'self' ${supabaseUrl} ${supabaseWs} ${backendUrl} https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com`,
+  // Demo video (Drive) and the checkout overlay.
+  "frame-src 'self' https://drive.google.com https://www.youtube-nocookie.com https://www.youtube.com https://app.lemonsqueezy.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  // Modern replacement for the X-Frame-Options below, which stays for old browsers.
+  "frame-ancestors 'self'",
+  // Skipped in dev: it would rewrite the http://localhost API calls to https.
+  ...(isDev ? [] : ["upgrade-insecure-requests"]),
+]
+  .filter(Boolean)
+  .join("; ");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
@@ -83,6 +121,30 @@ const nextConfig = {
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "X-Frame-Options", value: "SAMEORIGIN" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          // Two years, the value Lighthouse and OWASP both ask for. `preload` is
+          // deliberately absent: it needs a manual submission to
+          // hstspreload.org and is slow to undo, so it should be a conscious
+          // choice rather than a side effect of this commit.
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains",
+          },
+          // Isolates this window from cross-origin documents that open it.
+          // `-allow-popups` rather than plain `same-origin` so any popup we open
+          // (checkout) keeps its window.opener link. OAuth here is redirect
+          // based, so it is unaffected either way.
+          {
+            key: "Cross-Origin-Opener-Policy",
+            value: "same-origin-allow-popups",
+          },
+          // Report-only for now. Enforcing needs one of: nonces (costs static
+          // rendering), experimental.sri (keeps static, still experimental), or
+          // accepting 'unsafe-inline' (which Lighthouse will keep flagging).
+          // Collect real violations first, then pick.
+          {
+            key: "Content-Security-Policy-Report-Only",
+            value: contentSecurityPolicy,
+          },
         ],
       },
       {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -64,8 +64,6 @@
     "@tsparticles/engine": "^3.8.1",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.8.1",
-    "@vercel/analytics": "^1.5.0",
-    "@vercel/speed-insights": "^1.2.0",
     "ai": "latest",
     "autoprefixer": "^10.4.20",
     "axios": "catalog:",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,13 @@
   "name": "web",
   "version": "1.0.0",
   "private": true,
+  "browserslist": [
+    "chrome >= 92",
+    "edge >= 92",
+    "firefox >= 90",
+    "safari >= 15.4",
+    "ios_saf >= 15.4"
+  ],
   "scripts": {
     "dev": "next dev",
     "dev:new": "next dev -p 4000",

--- a/packages/ui/src/floating-dock.tsx
+++ b/packages/ui/src/floating-dock.tsx
@@ -58,6 +58,9 @@ const FloatingDockMobile = ({
                 <a
                   href={item.href}
                   key={item.title}
+                  // Icon-only link: without a name a screen reader announces just
+                  // "link". The title is a hover tooltip, so it can't supply one.
+                  aria-label={item.title}
                   className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-50 dark:bg-neutral-900"
                 >
                   <div className="h-4 w-4">{item.icon}</div>
@@ -155,7 +158,9 @@ function IconContainer({
   const [hovered, setHovered] = useState(false);
 
   return (
-    <a href={href}>
+    // Same as the mobile dock: the label only appears on hover, so the link
+    // needs its own accessible name.
+    <a href={href} aria-label={title}>
       <motion.div
         ref={ref}
         style={{ width, height }}

--- a/packages/ui/src/sparkles.tsx
+++ b/packages/ui/src/sparkles.tsx
@@ -40,6 +40,15 @@ export const SparklesCore = (props: ParticlesProps) => {
         // pay for the download either.
         if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
 
+        // Same bargain on phones: the particles sit behind centred text on a
+        // gradient — the heroes' decorative art is already `hidden md:flex` —
+        // so mobile was paying ~140kB plus a 60fps canvas loop for a decoration
+        // it barely shows, on exactly the low-end devices where that main-thread
+        // time costs the most.
+        // ponytail: checked on mount only, like the reduced-motion guard above.
+        // No resize listener — a phone rotated into >=768px just stays static.
+        if (window.matchMedia("(max-width: 767px)").matches) return;
+
         let cancelled = false;
         const start = async () => {
             const [{ initParticlesEngine }, { loadSlim }] = await Promise.all([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,12 +391,6 @@ importers:
       '@tsparticles/slim':
         specifier: ^3.8.1
         version: 3.9.1
-      '@vercel/analytics':
-        specifier: ^1.5.0
-        version: 1.5.0(next@15.2.8(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
-      '@vercel/speed-insights':
-        specifier: ^1.2.0
-        version: 1.2.0(next@15.2.8(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       ai:
         specifier: latest
         version: 6.0.134(zod@3.25.76)
@@ -607,7 +601,7 @@ importers:
         version: 29.6.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))
+        version: 29.7.0(@types/node@24.9.2)
       next:
         specifier: 15.2.8
         version: 15.2.8(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -4451,58 +4445,9 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
 
-  '@vercel/analytics@1.5.0':
-    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
-
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
-
-  '@vercel/speed-insights@1.2.0':
-    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
-    peerDependencies:
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -9820,6 +9765,41 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
+  '@jest/core@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.9
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.19.9)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.5.4))':
     dependencies:
       '@jest/console': 29.7.0
@@ -9905,41 +9885,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.5.4))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.9
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -12704,17 +12649,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.1.1
 
-  '@vercel/analytics@1.5.0(next@15.2.8(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
-    optionalDependencies:
-      next: 15.2.8(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-
   '@vercel/oidc@3.1.0': {}
-
-  '@vercel/speed-insights@1.2.0(next@15.2.8(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
-    optionalDependencies:
-      next: 15.2.8(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -13476,13 +13411,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@24.9.2):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.9.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -14947,16 +14882,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@24.9.2):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@24.9.2)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.9.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -14965,6 +14900,36 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.9):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.9
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.5.4)):
     dependencies:
@@ -15059,37 +15024,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.28.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.9
-      ts-node: 10.9.2(@types/node@24.9.2)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.28.0
@@ -15121,7 +15055,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@24.9.2):
     dependencies:
       '@babel/core': 7.28.0
       '@jest/test-sequencer': 29.7.0
@@ -15147,7 +15081,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.9.2
-      ts-node: 10.9.2(@types/node@24.9.2)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -15462,12 +15395,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@24.9.2):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@24.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -17833,25 +17766,6 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.5.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@24.9.2)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 24.9.2
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true


### PR DESCRIPTION
## What

Follow-ups from the latest PageSpeed run (92 mobile / ~99 desktop), plus two console errors traced to root cause.

**Performance**
1. **Render-blocking CSS (~930 ms mobile).** Enable `experimental.inlineCss` so the App Router emits Tailwind CSS as an inline `<style>` instead of a render-blocking `<link>`, removing the stylesheet request waterfall. This is the App-Router-correct feature — `optimizeCss`/critters is Pages-Router-only and can't process streamed HTML.
2. **Legacy JS polyfills (~12 KiB off first-load JS).** Added an explicit modern `browserslist`. Without it Next targets old Safari and SWC injects core-js polyfills for `Array.prototype.at/flat/flatMap`, `Object.fromEntries/hasOwn`, `String.prototype.trimStart/End` — all baseline in supported browsers (Chrome/Edge ≥92, Firefox ≥90, Safari/iOS ≥15.4, >95% of traffic).
3. **Oversized avatars (~9 KiB).** `avatar.vercel.sh` served 120×120 into a 32px slot; request `?size=64` (2× retina).
4. **Particle engine skipped on phones (~140kB + a 60fps canvas loop).** `SparklesCore` already deferred tsparticles to idle and skipped it for `prefers-reduced-motion`; mobile still paid full price for a decoration drawn behind centred text, while the heroes' decorative art is already `hidden md:flex`. Guarded on the `md` breakpoint next to the existing check, so every marketing hero benefits at once. Desktop unchanged.

**Bug fixes**
5. **Hero container was pinned, not centred.** `container mx-12` cancelled the Tailwind container's own `center: true` — the grid sat 3rem off-centre on desktop and lost ~96px of width on mobile. It was also the element PageSpeed flagged for layout shift.
6. **`<circle> attribute r: Expected length, "undefined"` console error.** `MotionProvider` loads its feature bundle via dynamic import, so slim `m` components render before features arrive — and a featureless `m` can't resolve `animate={{ r: [1,2,1] }}` to a single attribute value, so it wrote `r="undefined"`. Now pulses via `scale` (matching the sparks directly below it), which also composites instead of forcing layout each frame.

**Cleanup**
7. **Removed Vercel Analytics + Speed Insights.** `tryscriptai.com` resolves to the Lightsail box (`Via: 1.1 Caddy`, no `x-vercel-id`), and Vercel's insight scripts exist only as routes on Vercel's own edge — so `/_vercel/insights/script.js` and `/_vercel/speed-insights/script.js` fell through to the Next 404 page. Every visitor got two failed requests plus a "Refused to execute script" MIME-type error. Both components and their dependencies are removed; Google Analytics (which loads from Google, host-independent) remains the single source of analytics.

## Reviewer note — please verify #1 on a preview/staging build

`inlineCss` is still flagged **experimental** by Next and is **build-only (invisible in `next dev`)**. Before merging, please confirm on a real production build:
- Styling renders correctly across a few routes (home, blog, pricing).
- View-source shows CSS inlined (no render-blocking `<link rel=stylesheet>`).

Trade-off: inlined CSS isn't cached separately, so returning visitors re-fetch the ~30 KiB Tailwind bundle per load — the right side of the trade for a first-visitor-focused marketing site. One-flag revert if the build shows any issue.

## Deliberately not done

- **Unused CSS (24 KiB)** — one global Tailwind sheet serves both marketing and dashboard, so the landing page inevitably carries dashboard utilities. Splitting it is architectural, for an *Unscored* audit.
- **GTM (162 KiB, both top long tasks)** — already `strategy="lazyOnload"`; the payload is Google's code. Keeping GA is a deliberate product decision.
- **DOM size / remaining 0.007 CLS** — both informational/already green.