### PR TITLE
feat(blog): Spotter Studio alternatives + YouTube content calendar posts

### DIFF
--- a/apps/web/lib/blog-data.ts
+++ b/apps/web/lib/blog-data.ts
@@ -5231,6 +5231,383 @@ Whichever tool you choose, keep the discipline: an idea earns a filming slot whe
 - References: [vidIQ](https://vidiq.com/), [TubeBuddy](https://www.tubebuddy.com/), [1of10](https://1of10.com/), [OutlierKit pricing comparison](https://outlierkit.com/resources/vidiq-vs-tubebuddy/).
     `,
   },
+  {
+    slug: "best-spotter-studio-alternatives-for-youtube-ideation-2026",
+    title:
+      "7 Best Spotter Studio Alternatives for YouTube Ideation (2026)",
+    excerpt:
+      "Spotter Studio is 49 USD a month, has no permanent free tier, and is built for channels with a team. Here are seven alternatives compared on ideation depth, outlier data, channel fit and price.",
+    category: "Video Ideas",
+    author: "Creator AI Team",
+    date: "Aug 9, 2026",
+    readTime: "12 min read",
+    featured: false,
+    tags: ["Ideas", "AI Tools", "Comparison", "YouTube"],
+    seoTitle:
+      "7 Best Spotter Studio Alternatives for YouTube Ideation (2026)",
+    seoDescription:
+      "Spotter Studio costs 49 USD a month with no free tier. Compare 7 Spotter Studio alternatives on ideation depth, outlier data and price. Try Creator AI free.",
+    focusKeyword: "spotter studio alternatives",
+    keywords: [
+      "spotter studio alternative free",
+      "spotter studio vs 1of10",
+      "cheaper spotter studio competitor",
+      "youtube brainstorm tool for small channels",
+      "spotter studio pricing 2026",
+      "outlier discovery tools for youtube",
+    ],
+    faqs: [
+      {
+        question: "What are the best Spotter Studio alternatives in 2026?",
+        answer:
+          "It depends which half of Spotter Studio you actually use. For outlier discovery, 1of10 and OutlierKit are the closest substitutes. For concept generation grounded in your own channel, Creator AI is the closest. For keyword-led ideas plus general SEO tooling, vidIQ and TubeBuddy cover it at a fraction of the price.",
+      },
+      {
+        question: "Why do creators look for a Spotter Studio alternative?",
+        answer:
+          "Three reasons come up repeatedly: the 49 USD monthly entry price, the absence of a permanent free tier to test with, and the fact that the product is shaped around established channels with a producer and an editor. A solo creator under 50K subscribers pays for collaboration features they never open.",
+      },
+      {
+        question: "Is there a free Spotter Studio alternative?",
+        answer:
+          "Yes, several. vidIQ, TubeBuddy, 1of10 and OutlierKit all run permanent free tiers, and Creator AI's Starter plan includes 500 monthly credits with no card required. None of the free tiers match Spotter Studio's concept depth, but all of them let you test the workflow before paying.",
+      },
+      {
+        question: "How much does Spotter Studio cost in 2026?",
+        answer:
+          "49 USD per month, or 299 USD per year, which works out near 24.92 USD monthly. That covers Brainstorm, Outliers and Projects, one connected YouTube channel and two additional team members, with unlimited AI concepts, titles and thumbnails.",
+      },
+      {
+        question: "Is 1of10 a good Spotter Studio replacement?",
+        answer:
+          "Only for the outlier half. 1of10 surfaces videos that beat their own channel's average by large multiples, which is the strongest single signal in this category, but it does no synthesis and knows nothing about your channel. You supply the analysis layer that Spotter Studio's Brainstorm provides.",
+      },
+      {
+        question: "Which Spotter Studio alternative is best for small channels?",
+        answer:
+          "Under 10K subscribers, pair TubeBuddy's Pro tier with a free outlier browser and spend nothing else. The ideation gap at that size is usually not idea quality, it is that you have too little channel data for any tool to personalise against, which is a problem money does not solve.",
+      },
+      {
+        question: "Do any alternatives generate the script as well as the idea?",
+        answer:
+          "Creator AI does, and it is the main structural difference. Spotter Studio stops at the concept, title and thumbnail; the idea then gets pasted into a separate writing tool that has no knowledge of your channel. Creator AI carries the angle and hook straight through into a voice-matched script, subtitles and dubbing.",
+      },
+      {
+        question: "Does Spotter Studio have eligibility requirements?",
+        answer:
+          "Its positioning and pricing effectively gate it toward established channels rather than beginners, and there is no permanent free tier to evaluate it on a small channel. If you are early, that alone makes the alternatives the more sensible starting point.",
+      },
+    ],
+    content: `
+> **What are the best Spotter Studio alternatives in 2026?** It depends entirely on which half of the product you actually use. Spotter Studio does two distinct jobs, outlier discovery and AI concept development, and almost every alternative is strong at one and weak at the other. 1of10 and OutlierKit replace the outlier half cheaply. Creator AI replaces the concept half and carries the idea through into a finished script. vidIQ and TubeBuddy replace neither perfectly but cost a fraction of the price. This comparison sorts the seven realistic **spotter studio alternatives** by which job you are actually hiring the tool for.
+
+![Spotter Studio alternatives compared, the Creator AI ideation dashboard with scored video ideas](/ideation%20page.png)
+
+Spotter Studio is a good product. That is worth saying up front, because most "alternatives" articles are thinly disguised takedowns.
+
+It is also 49 USD a month, has no permanent free tier, and is built around a workflow that assumes you have a producer and an editor. If you are a solo creator with 20K subscribers, you are paying flagship pricing for collaboration features you will never open. That mismatch, not product quality, is why people search for **spotter studio alternatives**.
+
+## What You Are Actually Replacing
+
+Before comparing anything, be precise about what Spotter Studio gives you. Its published plan is 49 USD monthly or 299 USD annually, roughly 24.92 USD a month, and it includes:
+
+- **Brainstorm**, AI concept generation and pressure-testing, with unlimited concepts, titles and thumbnails
+- **Outliers**, tracking videos that dramatically overperformed their channel's average
+- **Projects**, a collaborative planner
+- One connected YouTube channel and two additional team members
+
+Now ask yourself which of those four you opened this week. Most creators who churn were using one and a half of them, and the honest **spotter studio alternatives** conversation starts there rather than with a feature grid.
+
+## Spotter Studio Alternatives Compared (2026)
+
+Published list prices checked August 2026, annual billing where offered. Prices move; treat these as bands.
+
+| Tool | Replaces which half | Free tier | Uses your channel data | Published price |
+|---|---|---|---|---|
+| Creator AI | Concept development, plus the script after it | Yes, 500 credits/mo | Yes, deep | Free, then 19 USD/mo |
+| 1of10 | Outlier discovery | Yes | No | Free, Basic 29 USD/mo, Pro 69 USD/mo |
+| OutlierKit | Outlier discovery, cheaper | Free trial | No | Around 29 USD/mo |
+| TubeLab | Outlier browsing, budget | Yes | No | Low-cost paid tiers |
+| vidIQ | Keyword-led ideas plus SEO tooling | Yes, 150 credits/mo | Yes | Free, Boost approx 16.58 USD/mo |
+| TubeBuddy | Analytics-led ideas plus bulk tooling | Yes | Yes | Free, Pro approx 3 USD/mo |
+| ChatGPT | Concept volume, no evidence | Limited | No | 20 USD/mo |
+
+Two things fall out of that table. First, nothing on it does both halves as completely as Spotter Studio, which is a fair point in its favour. Second, doing both halves badly for 49 USD is worse than doing the half you need well for 19.
+
+## 1. Creator AI, the Concept Half Plus Everything Downstream
+
+Disclosure: our product. Check the free tier rather than trusting the section.
+
+Creator AI's ideation is closest to Spotter Studio's Brainstorm, but grounded differently. Instead of generating concepts and asking you to judge them, it runs a five-stage pipeline: it loads the channel intelligence learned during AI training (your title patterns, hook patterns, topic clusters, upload cadence and content gaps), gathers trend intelligence from live YouTube data plus a Google-Search-grounded pass, synthesises ideas against both, runs a differentiation check against your last ten runs and against competitor content, then scores what survives.
+
+Each idea comes back with an angle, a hook, target keywords, a suggested format, talking points, real reference URLs, an opportunity score out of 100 and a momentum flag of rising, stable or declining. Alongside them you get a trend snapshot listing saturated topics to avoid and niche gaps to consider. Twenty ideas per run, on every plan including the free one.
+
+**The structural difference:** Spotter Studio stops at the concept. Creator AI carries the same angle into a story blueprint, a voice-matched script, a thumbnail and subtitles without you re-explaining the premise to a second tool.
+
+**Pros:** deepest channel personalisation here, deduplication so repeat runs produce genuinely new sets, PDF and JSON export, and a free tier that needs no card.
+
+**Cons:** ideation is gated behind training the AI on your channel, so there is a real first-run delay. Credit-metered rather than unlimited, so a heavy ideation month competes with your scripting budget. Weaker than 1of10 on raw outlier browsing.
+
+**Best for:** solo creators and small teams whose bottleneck is the whole pipeline, not ideation alone.
+
+## 2. 1of10, the Outlier Half, Done Properly
+
+If Outliers is the tab you actually live in, this is the closest of all the **spotter studio alternatives**.
+
+1of10 surfaces videos that beat their own channel's average by large multiples. That framing matters: a 30x outlier on a small channel controls for subscriber count and production quality, which makes the idea and the packaging the only variables left. It is the nearest thing to a controlled experiment YouTube offers.
+
+There is a free plan. Basic is 29 USD a month billed annually, Pro is 69 USD.
+
+**Pros:** the strongest single signal in the category, and a genuinely large dataset.
+
+**Cons:** no synthesis, no channel fit, no concept development. You are the analysis layer, which is exactly the work Brainstorm was doing for you.
+
+## 3. OutlierKit, the Same Idea for Less
+
+OutlierKit does outlier discovery at roughly 29 USD a month with a trial, and publishes a great deal of comparison content about this category. Smaller dataset than 1of10, thinner filtering, materially cheaper than Spotter Studio.
+
+**Best for:** creators who liked Outliers, never used Brainstorm, and want the bill halved.
+
+## 4. TubeLab, the Budget Browser
+
+Free tier, low-cost paid plans, same outlier premise with less depth. Worth ten minutes before you pay anyone. If it surfaces two ideas you would not have found, it has already outperformed its price.
+
+![How Spotter Studio alternatives differ on outlier data versus channel-fit scoring](/story%20page.png)
+
+## 5. vidIQ, Search Demand Instead of Concepts
+
+vidIQ approaches ideas through its keyword engine: topics surface because a query has volume and weak competition. Free tier gives 150 AI credits monthly; Boost is around 16.58 USD a month annually with 2,000 credits; Max is 39 USD monthly billed yearly.
+
+**Pros:** real search data, a Chrome extension that overlays numbers while you browse YouTube, and the whole SEO toolkit alongside.
+
+**Cons:** search volume is a weak proxy for browse and suggested demand, which is where most views now originate. Strong for tutorials and reviews, weak for entertainment and commentary where nobody searches for the video at all.
+
+## 6. TubeBuddy, the Cheapest Credible Option
+
+TubeBuddy's Ideas Lab ranks topics using your own video history, your comments and niche performance, and shows the metric behind each suggestion. Pro is roughly 3 USD a month annually; Legend, which carries the AI and A/B testing, is around 23 USD.
+
+**Pros:** the best price-to-value on this list by a distance, and A/B testing closes the loop between an idea and its packaging.
+
+**Cons:** suggestions skew conservative. Anchoring to what already worked reproduces your channel rather than breaking it out.
+
+## 7. ChatGPT, Volume Without Evidence
+
+Worth naming because plenty of people cancel a tool and fall back to this. ChatGPT will produce a hundred titles in a minute, none carrying a view count, a saturation check or any memory of your channel. It presents every idea as excellent because it has no mechanism for grading them. Useful for rewriting a title you already chose; not a replacement for either half of Spotter Studio. We covered the limits in [Creator AI vs ChatGPT](/blog/creator-ai-vs-chatgpt-for-youtube-creators).
+
+## Choosing in Under Two Minutes
+
+- **You used Outliers, not Brainstorm:** 1of10 if budget allows, OutlierKit if not.
+- **You used Brainstorm, not Outliers:** Creator AI, and you also get the script.
+- **You used both, and you have a team:** stay on Spotter Studio. Nothing here matches it on both axes at once.
+- **You are under 10K subscribers:** TubeBuddy Pro plus a free outlier browser. At that size no tool has enough of your data to personalise well, which is a data problem rather than a spending problem.
+- **You are paying separately for scripting, thumbnails and subtitles:** the comparison stops being about ideation and becomes a subscription-consolidation question.
+
+## The Honest Limit of All Seven
+
+Every tool here, Spotter Studio included, improves your hit rate on which video to make. None of them make the video good. [YouTube's creator guidance](https://www.youtube.com/creators/) keeps returning to the same point, and the platform's move toward viewer satisfaction as a ranking input sharpens it: what gets recommended is a video that delivers on its promise.
+
+Pick the tool with the shortest distance between "this is a good idea" and "this is a finished upload". For most creators that distance, and not the quality of the idea list, is where the month actually disappears.
+
+## Keep Reading
+
+- [Best AI Video Idea Generator for YouTube (6 Tools Compared)](/blog/best-ai-video-idea-generator-for-youtube-creators-2026)
+- [YouTube Video Ideation: The 7-Step System That Beats Guessing](/blog/youtube-video-ideation-system-for-youtube-creators-2026)
+- [How to Build a YouTube Content Calendar That Survives a Bad Week](/blog/how-to-build-a-youtube-content-calendar-that-survives-2026)
+- Run 20 scored ideas against your own channel, [start free](/signup) or [compare plans](/pricing).
+- References: [Spotter Studio](https://www.spotterstudio.com/), [1of10](https://www.1of10.com/), [OutlierKit](https://outlierkit.com/), [vidIQ pricing](https://vidiq.com/pricing/), [TubeBuddy pricing](https://www.tubebuddy.com/pricing/), [YouTube for Creators](https://www.youtube.com/creators/).
+    `,
+  },
+  {
+    slug: "how-to-build-a-youtube-content-calendar-that-survives-2026",
+    title:
+      "How to Build a YouTube Content Calendar That Survives a Bad Week",
+    excerpt:
+      "Most calendars die the first time life interferes. Here is how to build one with a real buffer, batch ideation feeding it, and slotting rules based on trend momentum rather than vibes.",
+    category: "Video Ideas",
+    author: "Creator AI Team",
+    date: "Aug 9, 2026",
+    readTime: "11 min read",
+    featured: false,
+    tags: ["Content Strategy", "Workflow", "Planning", "YouTube"],
+    seoTitle:
+      "YouTube Content Calendar: 5 Proven Rules for 2026",
+    seoDescription:
+      "Build a YouTube content calendar that survives a bad week, with batch ideation, a 4-week buffer and momentum-based slotting. Try Creator AI free.",
+    focusKeyword: "youtube content calendar",
+    keywords: [
+      "youtube content calendar template 2026",
+      "how to plan youtube uploads in advance",
+      "youtube upload schedule consistency",
+      "batch filming youtube videos workflow",
+      "content buffer for youtube creators",
+      "youtube posting frequency 2026",
+    ],
+    faqs: [
+      {
+        question: "What is a YouTube content calendar?",
+        answer:
+          "A YouTube content calendar is a dated plan mapping which video publishes when, together with the production steps behind each slot. The useful version tracks state, idea, scripted, filmed, edited, scheduled, rather than only listing titles against dates, because a calendar without state cannot tell you when you are about to miss.",
+      },
+      {
+        question: "How far ahead should a YouTube content calendar run?",
+        answer:
+          "Four to six weeks of committed slots, with ideas queued further out and scripts written only one to two weeks ahead. Further out and trend-sensitive ideas rot before you film. Closer in and one bad week collapses the schedule with nothing in reserve.",
+      },
+      {
+        question: "How many videos should I have banked?",
+        answer:
+          "Two to four finished videos is the commonly recommended buffer, and four weeks is the point where most creators report the anxiety disappearing. The buffer, not the calendar, is what actually makes you consistent, because it converts an emergency into a withdrawal.",
+      },
+      {
+        question: "How often should I upload to YouTube in 2026?",
+        answer:
+          "One to three videos a week suits most channels, with weekly being the common recommendation for creators without a production team. Consistency matters more than raw frequency: a predictable weekly upload beats an erratic three-a-week that stops for a month.",
+      },
+      {
+        question: "Does batch filming actually save time?",
+        answer:
+          "Substantially, because the overhead is in the setup rather than the recording. Creators who film three to five videos in one session commonly report saving 40 to 50 percent of production time compared with producing one at a time, and quality tends to rise because nothing is shot under deadline pressure.",
+      },
+      {
+        question: "How do I decide what goes in which calendar slot?",
+        answer:
+          "Sort by trend momentum, not by preference. Rising ideas go in the next two weeks while the window is open, stable evergreen ideas fill the buffer because they hold value indefinitely, and declining ideas are dated and archived rather than scheduled.",
+      },
+      {
+        question: "What should the ratio of evergreen to trending content be?",
+        answer:
+          "Roughly 70 percent evergreen and 30 percent trending for most channels. Evergreen compounds through search and suggested traffic and gives you a floor, trending buys reach spikes now. An all-trending channel has no floor when the trend passes.",
+      },
+      {
+        question: "What do I do when I miss an upload?",
+        answer:
+          "Publish from the buffer and treat the miss as a signal, not a failure. If you have drawn the buffer down twice in a quarter, your cadence is too aggressive for your production capacity and the correct fix is a slower schedule, not more discipline.",
+      },
+      {
+        question: "Should the calendar live in a spreadsheet or a tool?",
+        answer:
+          "Whichever one you will actually open on a Monday morning. A spreadsheet with an honest status column beats a sophisticated planner nobody updates. What matters is that ideation feeds it automatically, so slots get filled from a scored queue rather than from memory.",
+      },
+    ],
+    content: `
+> **How do you build a YouTube content calendar that actually survives?** Give it a buffer and a feeder. A **youtube content calendar** fails not because the dates were wrong but because it has no reserve when a week goes bad and no queue of ready ideas to refill from. Fix both and the calendar stops being a wish list: four to six weeks of committed slots, two to four finished videos banked, and a monthly batch ideation run that fills the queue with scored ideas instead of Sunday-night guesses.
+
+![Planning a YouTube content calendar from scored video ideas in Creator AI](/ideation%20page.png)
+
+Everyone has built one. A tidy grid, colour-coded, four months of upload dates filled in with confidence on a Sunday afternoon.
+
+Six weeks later it is a historical document.
+
+The failure is predictable and it is not discipline. A **youtube content calendar** built as a list of dated titles has no shock absorber, so the first time a shoot falls through, an edit runs long or you simply get ill, the whole structure collapses to whatever you can film tonight.
+
+## Why Most Calendars Die in Week Six
+
+Three structural faults, in order of how much damage they do.
+
+**No buffer.** If today's upload is filmed today, every bad day is a missed upload. There is no version of discipline that fixes this, only inventory.
+
+**No feeder.** The calendar has slots but no queue behind them. When slot 7 arrives empty you are ideating under deadline, which is when you pick the safe, saturated topic that underperforms.
+
+**No state.** A grid of titles against dates cannot tell you that four videos are scripted but none are filmed. You find that out on the Tuesday.
+
+A calendar that survives fixes all three, and the fixes are cheap.
+
+## Rule 1: Four to Six Weeks Committed, No More
+
+Commit slots four to six weeks out. Keep ideas queued further ahead, but write scripts only one to two weeks in advance.
+
+The window matters in both directions. Plan twelve months and your trend-sensitive ideas rot before the camera turns on, so you either film something stale or throw the plan away, which teaches you that plans are disposable. Plan two weeks and one bad week wipes you out.
+
+Four to six weeks is long enough to batch and short enough that the ideas are still true when you film them.
+
+## Rule 2: Bank Two to Four Videos Before You Publicise a Schedule
+
+This is the rule that actually produces consistency, and it is the one everybody skips because it means delaying the launch of your new schedule by a month.
+
+The common recommendation is a buffer of two to four finished videos, and a four-week buffer is where most creators report the weekly anxiety disappearing. A buffer converts an emergency into a withdrawal. You did not miss an upload; you published from inventory and spent the week rebuilding it.
+
+Practically: before announcing "new videos every Tuesday", have three Tuesdays already sitting finished on a drive.
+
+## Rule 3: Batch Film, Because the Cost Is Setup, Not Recording
+
+Lighting, camera, audio, wardrobe, mental gear-change. That overhead is nearly identical whether you record one video or four, which is why batching is the single largest time saving available to a solo creator, commonly reported at 40 to 50 percent of production time versus one-at-a-time production.
+
+Pick one filming day. Record three to five videos in the session. Quality usually improves rather than degrades, because nothing in that batch was shot the night before a deadline.
+
+Batch filming has one prerequisite, and it is the thing most creators do not have: three to five scripts ready at once. Which is a **youtube content calendar** feeder problem, not a filming problem.
+
+## Rule 4: Feed the Calendar From a Scored Queue, Not From Memory
+
+Here is where ideation and the calendar connect, and where most planning advice stops short.
+
+Filling slots from memory biases you toward whatever you thought about most recently and blinds you to what your audience asked for three months ago. Filling them from a scored queue does not.
+
+Run one ideation batch a month. Generate far more ideas than you need, twenty against a weekly schedule, so that rejecting fifteen costs nothing. Creator AI's ideation does this in a single run: it reads the channel intelligence learned from your videos, pulls live trend data, synthesises ideas against both, checks them against your last ten runs so nothing repeats, and returns each idea with an angle, a hook, target keywords, an opportunity score out of 100 and a momentum flag.
+
+Those last two fields are what make the queue sortable, which is the whole point.
+
+The mechanics of that pipeline are covered in [the 7-step ideation system](/blog/youtube-video-ideation-system-for-youtube-creators-2026), and the tool landscape in [our idea generator comparison](/blog/best-ai-video-idea-generator-for-youtube-creators-2026).
+
+## Rule 5: Slot by Momentum, Not by Preference
+
+With a scored queue, slotting stops being a preference argument:
+
+| Momentum | Score | Where it goes |
+|---|---|---|
+| Rising | High | Next two weeks, while the window is open |
+| Stable | High | Buffer and evergreen backlog |
+| Stable | Low | Rejected, revisit next quarter |
+| Declining | Any | Dated and archived, not scheduled |
+
+Rising ideas are perishable, so they get the near slots. Stable high-scorers are the correct thing to bank, because an evergreen video is just as good in six weeks as it is today, which is precisely what a buffer needs.
+
+Aim for roughly 70 percent evergreen and 30 percent trending across a quarter. Evergreen compounds through search and suggested traffic and forms your floor; trending buys reach now. A channel that is all trending has nothing holding it up when the trend passes.
+
+![Slotting scored ideas into a YouTube content calendar by trend momentum](/story%20page.png)
+
+## The Columns Your YouTube Content Calendar Actually Needs
+
+Skip the elaborate template. Six columns, in a spreadsheet you will actually open:
+
+1. **Publish date**
+2. **Working title** (from the idea's title variations)
+3. **Status**: idea, scripted, filmed, edited, scheduled
+4. **Momentum**: rising, stable, declining
+5. **Opportunity score**
+6. **Buffer position**: is this inventory, or is it due?
+
+Column 3 is the one that saves you. A calendar showing four scripted and zero filmed videos is telling you, on Monday, that Thursday is in trouble. A calendar of titles and dates tells you nothing until it is too late.
+
+## Choosing a Cadence You Can Actually Hold
+
+One to three videos a week suits most channels, and weekly is the standard recommendation for creators without a production team. But the number matters less than the predictability: [YouTube's own creator guidance](https://www.youtube.com/creators/) has been consistent that a schedule viewers can rely on outperforms raw volume, and the platform's move toward viewer satisfaction as a ranking input rewards deliverable promises over frequent ones.
+
+The test is unsentimental. Take your realistic production hours per week, divide by the hours one finished video genuinely takes you, and round down. If that number is 0.8, you are a fortnightly channel that has been lying to itself about being weekly.
+
+## When It Breaks Anyway
+
+It will. Handle it in this order:
+
+1. **Publish from the buffer.** That is what it is for. No apology video.
+2. **Rebuild before you add.** Next filming session refills inventory rather than extending the plan.
+3. **Count the withdrawals.** Two buffer draws in a quarter means the cadence exceeds your capacity, and the fix is a slower schedule rather than more willpower.
+4. **Never publish filler to protect a streak.** A weak upload costs you more than a skipped week, because the algorithm reads the disappointment and your audience remembers it.
+
+## What This Buys You
+
+A **youtube content calendar** with a buffer, a scored feeder and an honest status column removes two specific things: the Sunday-night scramble, and the filler video you upload to keep a streak alive. Neither felt like a strategic problem at the time. Both are why channels plateau.
+
+Get the plumbing right and consistency stops being a personality trait you have to summon every week. It becomes the default outcome of a system that already has next month's videos in it.
+
+## Keep Reading
+
+- [YouTube Video Ideation: The 7-Step System That Beats Guessing](/blog/youtube-video-ideation-system-for-youtube-creators-2026)
+- [7 Best Spotter Studio Alternatives for YouTube Ideation (2026)](/blog/best-spotter-studio-alternatives-for-youtube-ideation-2026)
+- [Story Structure 101: Plan Videos That People Actually Finish](/blog/youtube-video-story-structure-for-retention-2026)
+- Fill next month's slots from 20 scored ideas, [start free](/signup) or [compare plans](/pricing).
+- References: [YouTube for Creators](https://www.youtube.com/creators/), [TubeBuddy on content calendars](https://www.tubebuddy.com/blog/youtube-content-calendar/), [Google Trends](https://trends.google.com/trends/).
+    `,
+  },
 ];
 
 export function getBlogBySlug(slug: string): BlogPost | undefined {

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -4501,3 +4501,310 @@ A usable idea includes the angle, why it works, a hook concept, a suggested form
 
 **Do I still need to validate AI-generated ideas?**
 Yes. Treat any generated list as a shortlist, then check demand, competing coverage and channel fit before filming. Tools that already attach evidence and an opportunity score make that check minutes long instead of an hour.
+
+---
+
+## 7 Best Spotter Studio Alternatives for YouTube Ideation (2026)
+
+- URL: https://tryscriptai.com/blog/best-spotter-studio-alternatives-for-youtube-ideation-2026
+- Category: Video Ideas
+- Focus keyword: spotter studio alternatives
+- Summary: Spotter Studio is 49 USD a month, has no permanent free tier, and is built for channels with a team. Here are seven alternatives compared on ideation depth, outlier data, channel fit and price.
+
+> **What are the best Spotter Studio alternatives in 2026?** It depends entirely on which half of the product you actually use. Spotter Studio does two distinct jobs, outlier discovery and AI concept development, and almost every alternative is strong at one and weak at the other. 1of10 and OutlierKit replace the outlier half cheaply. Creator AI replaces the concept half and carries the idea through into a finished script. vidIQ and TubeBuddy replace neither perfectly but cost a fraction of the price. This comparison sorts the seven realistic **spotter studio alternatives** by which job you are actually hiring the tool for.
+
+![Spotter Studio alternatives compared, the Creator AI ideation dashboard with scored video ideas](/ideation%20page.png)
+
+Spotter Studio is a good product. That is worth saying up front, because most "alternatives" articles are thinly disguised takedowns.
+
+It is also 49 USD a month, has no permanent free tier, and is built around a workflow that assumes you have a producer and an editor. If you are a solo creator with 20K subscribers, you are paying flagship pricing for collaboration features you will never open. That mismatch, not product quality, is why people search for **spotter studio alternatives**.
+
+## What You Are Actually Replacing
+
+Before comparing anything, be precise about what Spotter Studio gives you. Its published plan is 49 USD monthly or 299 USD annually, roughly 24.92 USD a month, and it includes:
+
+- **Brainstorm**, AI concept generation and pressure-testing, with unlimited concepts, titles and thumbnails
+- **Outliers**, tracking videos that dramatically overperformed their channel's average
+- **Projects**, a collaborative planner
+- One connected YouTube channel and two additional team members
+
+Now ask yourself which of those four you opened this week. Most creators who churn were using one and a half of them, and the honest **spotter studio alternatives** conversation starts there rather than with a feature grid.
+
+## Spotter Studio Alternatives Compared (2026)
+
+Published list prices checked August 2026, annual billing where offered. Prices move; treat these as bands.
+
+| Tool | Replaces which half | Free tier | Uses your channel data | Published price |
+|---|---|---|---|---|
+| Creator AI | Concept development, plus the script after it | Yes, 500 credits/mo | Yes, deep | Free, then 19 USD/mo |
+| 1of10 | Outlier discovery | Yes | No | Free, Basic 29 USD/mo, Pro 69 USD/mo |
+| OutlierKit | Outlier discovery, cheaper | Free trial | No | Around 29 USD/mo |
+| TubeLab | Outlier browsing, budget | Yes | No | Low-cost paid tiers |
+| vidIQ | Keyword-led ideas plus SEO tooling | Yes, 150 credits/mo | Yes | Free, Boost approx 16.58 USD/mo |
+| TubeBuddy | Analytics-led ideas plus bulk tooling | Yes | Yes | Free, Pro approx 3 USD/mo |
+| ChatGPT | Concept volume, no evidence | Limited | No | 20 USD/mo |
+
+Two things fall out of that table. First, nothing on it does both halves as completely as Spotter Studio, which is a fair point in its favour. Second, doing both halves badly for 49 USD is worse than doing the half you need well for 19.
+
+## 1. Creator AI, the Concept Half Plus Everything Downstream
+
+Disclosure: our product. Check the free tier rather than trusting the section.
+
+Creator AI's ideation is closest to Spotter Studio's Brainstorm, but grounded differently. Instead of generating concepts and asking you to judge them, it runs a five-stage pipeline: it loads the channel intelligence learned during AI training (your title patterns, hook patterns, topic clusters, upload cadence and content gaps), gathers trend intelligence from live YouTube data plus a Google-Search-grounded pass, synthesises ideas against both, runs a differentiation check against your last ten runs and against competitor content, then scores what survives.
+
+Each idea comes back with an angle, a hook, target keywords, a suggested format, talking points, real reference URLs, an opportunity score out of 100 and a momentum flag of rising, stable or declining. Alongside them you get a trend snapshot listing saturated topics to avoid and niche gaps to consider. Twenty ideas per run, on every plan including the free one.
+
+**The structural difference:** Spotter Studio stops at the concept. Creator AI carries the same angle into a story blueprint, a voice-matched script, a thumbnail and subtitles without you re-explaining the premise to a second tool.
+
+**Pros:** deepest channel personalisation here, deduplication so repeat runs produce genuinely new sets, PDF and JSON export, and a free tier that needs no card.
+
+**Cons:** ideation is gated behind training the AI on your channel, so there is a real first-run delay. Credit-metered rather than unlimited, so a heavy ideation month competes with your scripting budget. Weaker than 1of10 on raw outlier browsing.
+
+**Best for:** solo creators and small teams whose bottleneck is the whole pipeline, not ideation alone.
+
+## 2. 1of10, the Outlier Half, Done Properly
+
+If Outliers is the tab you actually live in, this is the closest of all the **spotter studio alternatives**.
+
+1of10 surfaces videos that beat their own channel's average by large multiples. That framing matters: a 30x outlier on a small channel controls for subscriber count and production quality, which makes the idea and the packaging the only variables left. It is the nearest thing to a controlled experiment YouTube offers.
+
+There is a free plan. Basic is 29 USD a month billed annually, Pro is 69 USD.
+
+**Pros:** the strongest single signal in the category, and a genuinely large dataset.
+
+**Cons:** no synthesis, no channel fit, no concept development. You are the analysis layer, which is exactly the work Brainstorm was doing for you.
+
+## 3. OutlierKit, the Same Idea for Less
+
+OutlierKit does outlier discovery at roughly 29 USD a month with a trial, and publishes a great deal of comparison content about this category. Smaller dataset than 1of10, thinner filtering, materially cheaper than Spotter Studio.
+
+**Best for:** creators who liked Outliers, never used Brainstorm, and want the bill halved.
+
+## 4. TubeLab, the Budget Browser
+
+Free tier, low-cost paid plans, same outlier premise with less depth. Worth ten minutes before you pay anyone. If it surfaces two ideas you would not have found, it has already outperformed its price.
+
+![How Spotter Studio alternatives differ on outlier data versus channel-fit scoring](/story%20page.png)
+
+## 5. vidIQ, Search Demand Instead of Concepts
+
+vidIQ approaches ideas through its keyword engine: topics surface because a query has volume and weak competition. Free tier gives 150 AI credits monthly; Boost is around 16.58 USD a month annually with 2,000 credits; Max is 39 USD monthly billed yearly.
+
+**Pros:** real search data, a Chrome extension that overlays numbers while you browse YouTube, and the whole SEO toolkit alongside.
+
+**Cons:** search volume is a weak proxy for browse and suggested demand, which is where most views now originate. Strong for tutorials and reviews, weak for entertainment and commentary where nobody searches for the video at all.
+
+## 6. TubeBuddy, the Cheapest Credible Option
+
+TubeBuddy's Ideas Lab ranks topics using your own video history, your comments and niche performance, and shows the metric behind each suggestion. Pro is roughly 3 USD a month annually; Legend, which carries the AI and A/B testing, is around 23 USD.
+
+**Pros:** the best price-to-value on this list by a distance, and A/B testing closes the loop between an idea and its packaging.
+
+**Cons:** suggestions skew conservative. Anchoring to what already worked reproduces your channel rather than breaking it out.
+
+## 7. ChatGPT, Volume Without Evidence
+
+Worth naming because plenty of people cancel a tool and fall back to this. ChatGPT will produce a hundred titles in a minute, none carrying a view count, a saturation check or any memory of your channel. It presents every idea as excellent because it has no mechanism for grading them. Useful for rewriting a title you already chose; not a replacement for either half of Spotter Studio. We covered the limits in [Creator AI vs ChatGPT](/blog/creator-ai-vs-chatgpt-for-youtube-creators).
+
+## Choosing in Under Two Minutes
+
+- **You used Outliers, not Brainstorm:** 1of10 if budget allows, OutlierKit if not.
+- **You used Brainstorm, not Outliers:** Creator AI, and you also get the script.
+- **You used both, and you have a team:** stay on Spotter Studio. Nothing here matches it on both axes at once.
+- **You are under 10K subscribers:** TubeBuddy Pro plus a free outlier browser. At that size no tool has enough of your data to personalise well, which is a data problem rather than a spending problem.
+- **You are paying separately for scripting, thumbnails and subtitles:** the comparison stops being about ideation and becomes a subscription-consolidation question.
+
+## The Honest Limit of All Seven
+
+Every tool here, Spotter Studio included, improves your hit rate on which video to make. None of them make the video good. [YouTube's creator guidance](https://www.youtube.com/creators/) keeps returning to the same point, and the platform's move toward viewer satisfaction as a ranking input sharpens it: what gets recommended is a video that delivers on its promise.
+
+Pick the tool with the shortest distance between "this is a good idea" and "this is a finished upload". For most creators that distance, and not the quality of the idea list, is where the month actually disappears.
+
+## Keep Reading
+
+- [Best AI Video Idea Generator for YouTube (6 Tools Compared)](/blog/best-ai-video-idea-generator-for-youtube-creators-2026)
+- [YouTube Video Ideation: The 7-Step System That Beats Guessing](/blog/youtube-video-ideation-system-for-youtube-creators-2026)
+- [How to Build a YouTube Content Calendar That Survives a Bad Week](/blog/how-to-build-a-youtube-content-calendar-that-survives-2026)
+- Run 20 scored ideas against your own channel, [start free](/signup) or [compare plans](/pricing).
+- References: [Spotter Studio](https://www.spotterstudio.com/), [1of10](https://www.1of10.com/), [OutlierKit](https://outlierkit.com/), [vidIQ pricing](https://vidiq.com/pricing/), [TubeBuddy pricing](https://www.tubebuddy.com/pricing/), [YouTube for Creators](https://www.youtube.com/creators/).
+
+### FAQ
+
+**What are the best Spotter Studio alternatives in 2026?**
+It depends which half of Spotter Studio you actually use. For outlier discovery, 1of10 and OutlierKit are the closest substitutes. For concept generation grounded in your own channel, Creator AI is the closest. For keyword-led ideas plus general SEO tooling, vidIQ and TubeBuddy cover it at a fraction of the price.
+
+**Why do creators look for a Spotter Studio alternative?**
+Three reasons come up repeatedly: the 49 USD monthly entry price, the absence of a permanent free tier to test with, and the fact that the product is shaped around established channels with a producer and an editor. A solo creator under 50K subscribers pays for collaboration features they never open.
+
+**Is there a free Spotter Studio alternative?**
+Yes, several. vidIQ, TubeBuddy, 1of10 and OutlierKit all run permanent free tiers, and Creator AI's Starter plan includes 500 monthly credits with no card required. None of the free tiers match Spotter Studio's concept depth, but all of them let you test the workflow before paying.
+
+**How much does Spotter Studio cost in 2026?**
+49 USD per month, or 299 USD per year, which works out near 24.92 USD monthly. That covers Brainstorm, Outliers and Projects, one connected YouTube channel and two additional team members, with unlimited AI concepts, titles and thumbnails.
+
+**Is 1of10 a good Spotter Studio replacement?**
+Only for the outlier half. 1of10 surfaces videos that beat their own channel's average by large multiples, which is the strongest single signal in this category, but it does no synthesis and knows nothing about your channel. You supply the analysis layer that Spotter Studio's Brainstorm provides.
+
+**Which Spotter Studio alternative is best for small channels?**
+Under 10K subscribers, pair TubeBuddy's Pro tier with a free outlier browser and spend nothing else. The ideation gap at that size is usually not idea quality, it is that you have too little channel data for any tool to personalise against, which is a problem money does not solve.
+
+**Do any alternatives generate the script as well as the idea?**
+Creator AI does, and it is the main structural difference. Spotter Studio stops at the concept, title and thumbnail; the idea then gets pasted into a separate writing tool that has no knowledge of your channel. Creator AI carries the angle and hook straight through into a voice-matched script, subtitles and dubbing.
+
+**Does Spotter Studio have eligibility requirements?**
+Its positioning and pricing effectively gate it toward established channels rather than beginners, and there is no permanent free tier to evaluate it on a small channel. If you are early, that alone makes the alternatives the more sensible starting point.
+
+---
+
+## How to Build a YouTube Content Calendar That Survives a Bad Week
+
+- URL: https://tryscriptai.com/blog/how-to-build-a-youtube-content-calendar-that-survives-2026
+- Category: Video Ideas
+- Focus keyword: youtube content calendar
+- Summary: Most calendars die the first time life interferes. Here is how to build one with a real buffer, batch ideation feeding it, and slotting rules based on trend momentum rather than vibes.
+
+> **How do you build a YouTube content calendar that actually survives?** Give it a buffer and a feeder. A **youtube content calendar** fails not because the dates were wrong but because it has no reserve when a week goes bad and no queue of ready ideas to refill from. Fix both and the calendar stops being a wish list: four to six weeks of committed slots, two to four finished videos banked, and a monthly batch ideation run that fills the queue with scored ideas instead of Sunday-night guesses.
+
+![Planning a YouTube content calendar from scored video ideas in Creator AI](/ideation%20page.png)
+
+Everyone has built one. A tidy grid, colour-coded, four months of upload dates filled in with confidence on a Sunday afternoon.
+
+Six weeks later it is a historical document.
+
+The failure is predictable and it is not discipline. A **youtube content calendar** built as a list of dated titles has no shock absorber, so the first time a shoot falls through, an edit runs long or you simply get ill, the whole structure collapses to whatever you can film tonight.
+
+## Why Most Calendars Die in Week Six
+
+Three structural faults, in order of how much damage they do.
+
+**No buffer.** If today's upload is filmed today, every bad day is a missed upload. There is no version of discipline that fixes this, only inventory.
+
+**No feeder.** The calendar has slots but no queue behind them. When slot 7 arrives empty you are ideating under deadline, which is when you pick the safe, saturated topic that underperforms.
+
+**No state.** A grid of titles against dates cannot tell you that four videos are scripted but none are filmed. You find that out on the Tuesday.
+
+A calendar that survives fixes all three, and the fixes are cheap.
+
+## Rule 1: Four to Six Weeks Committed, No More
+
+Commit slots four to six weeks out. Keep ideas queued further ahead, but write scripts only one to two weeks in advance.
+
+The window matters in both directions. Plan twelve months and your trend-sensitive ideas rot before the camera turns on, so you either film something stale or throw the plan away, which teaches you that plans are disposable. Plan two weeks and one bad week wipes you out.
+
+Four to six weeks is long enough to batch and short enough that the ideas are still true when you film them.
+
+## Rule 2: Bank Two to Four Videos Before You Publicise a Schedule
+
+This is the rule that actually produces consistency, and it is the one everybody skips because it means delaying the launch of your new schedule by a month.
+
+The common recommendation is a buffer of two to four finished videos, and a four-week buffer is where most creators report the weekly anxiety disappearing. A buffer converts an emergency into a withdrawal. You did not miss an upload; you published from inventory and spent the week rebuilding it.
+
+Practically: before announcing "new videos every Tuesday", have three Tuesdays already sitting finished on a drive.
+
+## Rule 3: Batch Film, Because the Cost Is Setup, Not Recording
+
+Lighting, camera, audio, wardrobe, mental gear-change. That overhead is nearly identical whether you record one video or four, which is why batching is the single largest time saving available to a solo creator, commonly reported at 40 to 50 percent of production time versus one-at-a-time production.
+
+Pick one filming day. Record three to five videos in the session. Quality usually improves rather than degrades, because nothing in that batch was shot the night before a deadline.
+
+Batch filming has one prerequisite, and it is the thing most creators do not have: three to five scripts ready at once. Which is a **youtube content calendar** feeder problem, not a filming problem.
+
+## Rule 4: Feed the Calendar From a Scored Queue, Not From Memory
+
+Here is where ideation and the calendar connect, and where most planning advice stops short.
+
+Filling slots from memory biases you toward whatever you thought about most recently and blinds you to what your audience asked for three months ago. Filling them from a scored queue does not.
+
+Run one ideation batch a month. Generate far more ideas than you need, twenty against a weekly schedule, so that rejecting fifteen costs nothing. Creator AI's ideation does this in a single run: it reads the channel intelligence learned from your videos, pulls live trend data, synthesises ideas against both, checks them against your last ten runs so nothing repeats, and returns each idea with an angle, a hook, target keywords, an opportunity score out of 100 and a momentum flag.
+
+Those last two fields are what make the queue sortable, which is the whole point.
+
+The mechanics of that pipeline are covered in [the 7-step ideation system](/blog/youtube-video-ideation-system-for-youtube-creators-2026), and the tool landscape in [our idea generator comparison](/blog/best-ai-video-idea-generator-for-youtube-creators-2026).
+
+## Rule 5: Slot by Momentum, Not by Preference
+
+With a scored queue, slotting stops being a preference argument:
+
+| Momentum | Score | Where it goes |
+|---|---|---|
+| Rising | High | Next two weeks, while the window is open |
+| Stable | High | Buffer and evergreen backlog |
+| Stable | Low | Rejected, revisit next quarter |
+| Declining | Any | Dated and archived, not scheduled |
+
+Rising ideas are perishable, so they get the near slots. Stable high-scorers are the correct thing to bank, because an evergreen video is just as good in six weeks as it is today, which is precisely what a buffer needs.
+
+Aim for roughly 70 percent evergreen and 30 percent trending across a quarter. Evergreen compounds through search and suggested traffic and forms your floor; trending buys reach now. A channel that is all trending has nothing holding it up when the trend passes.
+
+![Slotting scored ideas into a YouTube content calendar by trend momentum](/story%20page.png)
+
+## The Columns Your YouTube Content Calendar Actually Needs
+
+Skip the elaborate template. Six columns, in a spreadsheet you will actually open:
+
+1. **Publish date**
+2. **Working title** (from the idea's title variations)
+3. **Status**: idea, scripted, filmed, edited, scheduled
+4. **Momentum**: rising, stable, declining
+5. **Opportunity score**
+6. **Buffer position**: is this inventory, or is it due?
+
+Column 3 is the one that saves you. A calendar showing four scripted and zero filmed videos is telling you, on Monday, that Thursday is in trouble. A calendar of titles and dates tells you nothing until it is too late.
+
+## Choosing a Cadence You Can Actually Hold
+
+One to three videos a week suits most channels, and weekly is the standard recommendation for creators without a production team. But the number matters less than the predictability: [YouTube's own creator guidance](https://www.youtube.com/creators/) has been consistent that a schedule viewers can rely on outperforms raw volume, and the platform's move toward viewer satisfaction as a ranking input rewards deliverable promises over frequent ones.
+
+The test is unsentimental. Take your realistic production hours per week, divide by the hours one finished video genuinely takes you, and round down. If that number is 0.8, you are a fortnightly channel that has been lying to itself about being weekly.
+
+## When It Breaks Anyway
+
+It will. Handle it in this order:
+
+1. **Publish from the buffer.** That is what it is for. No apology video.
+2. **Rebuild before you add.** Next filming session refills inventory rather than extending the plan.
+3. **Count the withdrawals.** Two buffer draws in a quarter means the cadence exceeds your capacity, and the fix is a slower schedule rather than more willpower.
+4. **Never publish filler to protect a streak.** A weak upload costs you more than a skipped week, because the algorithm reads the disappointment and your audience remembers it.
+
+## What This Buys You
+
+A **youtube content calendar** with a buffer, a scored feeder and an honest status column removes two specific things: the Sunday-night scramble, and the filler video you upload to keep a streak alive. Neither felt like a strategic problem at the time. Both are why channels plateau.
+
+Get the plumbing right and consistency stops being a personality trait you have to summon every week. It becomes the default outcome of a system that already has next month's videos in it.
+
+## Keep Reading
+
+- [YouTube Video Ideation: The 7-Step System That Beats Guessing](/blog/youtube-video-ideation-system-for-youtube-creators-2026)
+- [7 Best Spotter Studio Alternatives for YouTube Ideation (2026)](/blog/best-spotter-studio-alternatives-for-youtube-ideation-2026)
+- [Story Structure 101: Plan Videos That People Actually Finish](/blog/youtube-video-story-structure-for-retention-2026)
+- Fill next month's slots from 20 scored ideas, [start free](/signup) or [compare plans](/pricing).
+- References: [YouTube for Creators](https://www.youtube.com/creators/), [TubeBuddy on content calendars](https://www.tubebuddy.com/blog/youtube-content-calendar/), [Google Trends](https://trends.google.com/trends/).
+
+### FAQ
+
+**What is a YouTube content calendar?**
+A YouTube content calendar is a dated plan mapping which video publishes when, together with the production steps behind each slot. The useful version tracks state, idea, scripted, filmed, edited, scheduled, rather than only listing titles against dates, because a calendar without state cannot tell you when you are about to miss.
+
+**How far ahead should a YouTube content calendar run?**
+Four to six weeks of committed slots, with ideas queued further out and scripts written only one to two weeks ahead. Further out and trend-sensitive ideas rot before you film. Closer in and one bad week collapses the schedule with nothing in reserve.
+
+**How many videos should I have banked?**
+Two to four finished videos is the commonly recommended buffer, and four weeks is the point where most creators report the anxiety disappearing. The buffer, not the calendar, is what actually makes you consistent, because it converts an emergency into a withdrawal.
+
+**How often should I upload to YouTube in 2026?**
+One to three videos a week suits most channels, with weekly being the common recommendation for creators without a production team. Consistency matters more than raw frequency: a predictable weekly upload beats an erratic three-a-week that stops for a month.
+
+**Does batch filming actually save time?**
+Substantially, because the overhead is in the setup rather than the recording. Creators who film three to five videos in one session commonly report saving 40 to 50 percent of production time compared with producing one at a time, and quality tends to rise because nothing is shot under deadline pressure.
+
+**How do I decide what goes in which calendar slot?**
+Sort by trend momentum, not by preference. Rising ideas go in the next two weeks while the window is open, stable evergreen ideas fill the buffer because they hold value indefinitely, and declining ideas are dated and archived rather than scheduled.
+
+**What should the ratio of evergreen to trending content be?**
+Roughly 70 percent evergreen and 30 percent trending for most channels. Evergreen compounds through search and suggested traffic and gives you a floor, trending buys reach spikes now. An all-trending channel has no floor when the trend passes.
+
+**What do I do when I miss an upload?**
+Publish from the buffer and treat the miss as a signal, not a failure. If you have drawn the buffer down twice in a quarter, your cadence is too aggressive for your production capacity and the correct fix is a slower schedule, not more discipline.
+
+**Should the calendar live in a spreadsheet or a tool?**
+Whichever one you will actually open on a Monday morning. A spreadsheet with an honest status column beats a sophisticated planner nobody updates. What matters is that ideation feeds it automatically, so slots get filled from a scored queue rather than from memory.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -95,6 +95,8 @@ Full text of every article below is available at https://tryscriptai.com/llms-fu
 - [How to Find Trending YouTube Video Topics (Step-by-Step)](https://tryscriptai.com/blog/how-to-find-trending-youtube-video-topics-2026): Stop guessing what your audience wants. A step-by-step guide to finding trending YouTube topics with analytics, Google Trends, and AI.
 - [YouTube Video Ideation: The 7-Step System That Beats Guessing](https://tryscriptai.com/blog/youtube-video-ideation-system-for-youtube-creators-2026): Most videos fail before the camera turns on, at the idea. Here is the 7-step ideation system that replaces brainstorming with evidence, and how to run it in minutes instead of hours.
 - [Best AI Video Idea Generator for YouTube (6 Tools Compared)](https://tryscriptai.com/blog/best-ai-video-idea-generator-for-youtube-creators-2026): Most idea generators hand you a list of titles with nothing behind them. We compared six tools on evidence, channel fit, packaging and price, and named the gap they all share.
+- [7 Best Spotter Studio Alternatives for YouTube Ideation (2026)](https://tryscriptai.com/blog/best-spotter-studio-alternatives-for-youtube-ideation-2026): Spotter Studio is 49 USD a month with no permanent free tier. Seven alternatives compared on which half of the product you actually use, outlier discovery or concept development.
+- [How to Build a YouTube Content Calendar That Survives a Bad Week](https://tryscriptai.com/blog/how-to-build-a-youtube-content-calendar-that-survives-2026): Most calendars die in week six for structural reasons: no buffer, no feeder, no state. Five rules that fix all three, with batch ideation filling the slots.
 
 ### Subtitles
 


### PR DESCRIPTION
Two new posts in the **Video Ideas** cluster, both featuring the ideation feature.

### Why these two angles

`main` already carries two ideation posts merged on Aug 2 — `youtube-video-ideation-system-for-youtube-creators-2026` (FK `youtube video ideation`) and `best-ai-video-idea-generator-for-youtube-creators-2026` (FK `ai video idea generator`). These two deliberately sit beside them rather than on top of them, so nothing cannibalises:

| Post | Focus keyword | Intent it serves |
|---|---|---|
| 7 Best Spotter Studio Alternatives for YouTube Ideation (2026) | `spotter studio alternatives` | Competitor-alternative, high commercial intent |
| How to Build a YouTube Content Calendar That Survives a Bad Week | `youtube content calendar` | Planning layer downstream of ideation |

Both interlink with the existing pair, so the four form a proper topic cluster.

### Research behind them

- Spotter Studio: 49 USD/mo or 299 USD/yr, no permanent free tier, shaped for established channels with a team. Compared against 1of10, OutlierKit, TubeLab, vidIQ, TubeBuddy, ChatGPT and Creator AI, with published prices checked August 2026 and the comparison split by *which half* of Spotter Studio the reader actually uses.
- Content calendar: 1–3 uploads/week as the common band, 2–4 video buffer, 40–50% production time saved by batching, and momentum-based slotting driven by the ideation pipeline's opportunity score and rising/stable/declining flag.

Ideation claims are written against the real pipeline in `packages/workers/src/processor/ideation.processor.ts` — five stages, 20 ideas per run uncapped by plan, dedup against the last ten runs, training gate — including the honest caveats (training prerequisite, credit metering).

### Checks

- `pnpm --filter web seo:audit` → **All posts pass ✓** (30 posts)
- `tsc --noEmit` clean
- `llms.txt` index entries + full `llms-full.txt` content blocks added
- Sitemap and blog routes pick both up automatically from `blogPosts`

Images reuse existing `public/ideation page.png` and `public/story page.png`; no new assets needed.