### PR TITLE
fix(dubbing): stop paying for dubs we cannot bill, and clean up after rejected ones

### DIFF
--- a/apps/api/src/dubbing/dubbing.controller.ts
+++ b/apps/api/src/dubbing/dubbing.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { createJobSSE } from '../common/sse';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
 
 @ApiTags('dubbing')
@@ -32,7 +33,7 @@ export class DubbingController {
   }
 
   @Post('sign-upload')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get a signed URL to upload source media to GCS',
@@ -61,7 +62,7 @@ export class DubbingController {
   }
 
   @Post()
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Create a dubbing job from an uploaded object',
@@ -90,7 +91,7 @@ export class DubbingController {
   }
 
   @Post(':id/regenerate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Regenerate a dub from its original media',

--- a/apps/api/src/dubbing/dubbing.service.spec.ts
+++ b/apps/api/src/dubbing/dubbing.service.spec.ts
@@ -10,6 +10,7 @@ import { getQueueToken } from '@nestjs/bullmq';
 import { DubbingService } from './dubbing.service';
 import { SupabaseService } from '../supabase/supabase.service';
 import { DUBBING_CANCEL_PREFIX } from '@repo/validation';
+import { deleteGcsObject, moveGcsObject } from '../utils';
 
 jest.mock('../utils', () => ({
   getSignedUploadUrl: jest.fn().mockResolvedValue('https://signed-upload-url'),
@@ -17,6 +18,7 @@ jest.mock('../utils', () => ({
   gcsPublicUrl: jest.fn(() => 'https://storage.googleapis.com/dub-bucket/obj'),
   gcsUri: jest.fn(() => 'gs://dub-bucket/obj'),
   deleteGcsObject: jest.fn().mockResolvedValue(undefined),
+  moveGcsObject: jest.fn().mockResolvedValue(undefined),
   getDubbingBucketName: jest.fn(() => 'dub-bucket'),
 }));
 
@@ -39,6 +41,7 @@ describe('DubbingService', () => {
   let service: DubbingService;
   let tables: Record<string, any>;
   let queue: { add: jest.Mock; getJob: jest.Mock; client: Promise<any> };
+  let rpc: jest.Mock;
   let redis: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
 
   function planResult(name: string | null) {
@@ -46,6 +49,7 @@ describe('DubbingService', () => {
   }
 
   async function build(overrides: Partial<Record<string, any>> = {}) {
+    jest.clearAllMocks();
     tables = {
       subscriptions: chain(planResult('Creator')),
       profiles: chain({ data: { credits: 10_000 }, error: null }),
@@ -55,7 +59,10 @@ describe('DubbingService', () => {
     redis = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
     queue = { add: jest.fn(), getJob: jest.fn(), client: Promise.resolve(redis) };
 
-    const mockSupabase = { getClient: () => ({ from: (t: string) => tables[t] }) };
+    // update_user_credits is the reservation/refund RPC - floored at zero in Postgres,
+    // so "not enough credits" surfaces here as an error, not a negative balance.
+    rpc = jest.fn().mockResolvedValue({ error: null });
+    const mockSupabase = { getClient: () => ({ from: (t: string) => tables[t], rpc }) };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DubbingService,
@@ -126,17 +133,25 @@ describe('DubbingService', () => {
       ).rejects.toThrow(PayloadTooLargeException);
     });
 
-    it('returns a signed URL scoped to the user prefix for a paid plan', async () => {
+    it('returns a signed URL scoped to the user prefix under staging', async () => {
       await build();
       const res = await service.signUpload(input, USER);
       expect(res.uploadUrl).toBe('https://signed-upload-url');
-      expect(res.objectName.startsWith(`${USER}/dubbing/`)).toBe(true);
+      // staging/, not the permanent path: an upload nobody claims must expire on its own.
+      expect(res.objectName.startsWith(`staging/${USER}/dubbing/`)).toBe(true);
+    });
+
+    // Regression: the balance was only checked at createDub, so a user short on credits
+    // pushed up to 500MB to GCS and was only then told they could not afford it.
+    it('rejects an unaffordable dub before the upload starts', async () => {
+      await build({ profiles: chain({ data: { credits: 10 }, error: null }) });
+      await expect(service.signUpload(input, USER)).rejects.toThrow(ForbiddenException);
     });
   });
 
   describe('createDub', () => {
     const input = {
-      objectName: `${USER}/dubbing/123_a.mp3`,
+      objectName: `staging/${USER}/dubbing/123_a.mp3`,
       targetLanguage: 'es',
       isVideo: false,
       mediaName: 'My clip',
@@ -146,7 +161,7 @@ describe('DubbingService', () => {
     it("rejects an object outside the user's prefix", async () => {
       await build();
       await expect(
-        service.createDub({ ...input, objectName: 'other-user/dubbing/x.mp3' }, USER),
+        service.createDub({ ...input, objectName: 'staging/other-user/dubbing/x.mp3' }, USER),
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -164,11 +179,60 @@ describe('DubbingService', () => {
       expect(queue.add).not.toHaveBeenCalled();
     });
 
+    // Regression: a rejected dub used to leave the uploaded media sitting in the bucket.
+    it('deletes the staged upload when the dub is rejected', async () => {
+      await build({ profiles: chain({ data: { credits: 50 }, error: null }) });
+      await expect(service.createDub(input, USER)).rejects.toThrow(ForbiddenException);
+      expect(deleteGcsObject).toHaveBeenCalledWith(expect.anything(), input.objectName, 'dub-bucket');
+    });
+
+    it('promotes the staged object out of staging once accepted', async () => {
+      await build();
+      await service.createDub(input, USER);
+      expect(moveGcsObject).toHaveBeenCalledWith(
+        expect.anything(),
+        input.objectName,
+        `${USER}/dubbing/123_a.mp3`,
+        'dub-bucket',
+      );
+    });
+
+    // Reserving up front is what stops two concurrent dubs from both passing the
+    // precheck and only failing to bill after ElevenLabs has already run.
+    it('reserves the full cost before enqueueing', async () => {
+      await build();
+      await service.createDub(input, USER);
+      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: -90 });
+      expect(queue.add).toHaveBeenCalledWith(
+        'dubbing',
+        expect.objectContaining({ reservedCredits: 90 }),
+        expect.anything(),
+      );
+    });
+
+    it('refunds and cleans up when the reservation succeeds but the insert fails', async () => {
+      await build({ dubbing_projects: chain({ data: null, error: { message: 'boom' } }) });
+      await expect(service.createDub(input, USER)).rejects.toThrow();
+      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: 90 });
+      expect(deleteGcsObject).toHaveBeenCalledWith(expect.anything(), `${USER}/dubbing/123_a.mp3`, 'dub-bucket');
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it('rejects the second of two concurrent dubs at the reservation', async () => {
+      await build();
+      rpc.mockResolvedValueOnce({ error: { message: 'Insufficient credits' } });
+      await expect(service.createDub(input, USER)).rejects.toThrow(ForbiddenException);
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
     it('inserts the project and enqueues the worker job', async () => {
       await build();
       const res = await service.createDub(input, USER);
       expect(res.projectId).toBeTruthy();
-      expect(res.jobId).toMatch(/^dubbing-user-1-/);
+      // A random id, not `dubbing-{userId}-{ms}`: the SSE status route is unauthenticated,
+      // so a guessable job id would let a stranger watch someone else's dub.
+      expect(res.jobId).toMatch(/^dubbing-[0-9a-f-]{36}$/);
+      expect(res.jobId).not.toContain(USER);
       expect(queue.add).toHaveBeenCalledWith(
         'dubbing',
         expect.objectContaining({ userId: USER, targetLanguage: 'es', durationSeconds: 30 }),
@@ -191,12 +255,14 @@ describe('DubbingService', () => {
       await build();
       const remove = jest.fn();
       queue.getJob.mockResolvedValue({
-        data: { userId: USER, projectId: 'p-1' },
+        data: { userId: USER, projectId: 'p-1', reservedCredits: 90 },
         getState: () => Promise.resolve('waiting'),
         remove,
       });
       const res = await service.stopDub(USER, 'job-1');
       expect(remove).toHaveBeenCalled();
+      // The worker never ran it, so the API owns the refund here.
+      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: 90 });
       expect(tables.dubbing_projects.update).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'failed', error_message: 'Cancelled by user' }),
       );
@@ -211,7 +277,38 @@ describe('DubbingService', () => {
       });
       const res = await service.stopDub(USER, 'job-1');
       expect(redis.set).toHaveBeenCalledWith(`${DUBBING_CANCEL_PREFIX}job-1`, '1', 'EX', 3600);
-      expect(res.message).toBe('Cancellation requested');
+      expect(res.message).toMatch(/^Cancellation requested/);
+      // The worker refunds an active job when it aborts - the API must not double-refund.
+      expect(rpc).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('in-flight guards', () => {
+    const row = {
+      input_gs_uri: 'gs://dub-bucket/user-1/dubbing/a.mp3',
+      input_url: 'https://storage.googleapis.com/dub-bucket/user-1/dubbing/a.mp3',
+      target_language: 'es',
+      target_accent: null,
+      is_video: false,
+      duration_seconds: 30,
+    };
+
+    it.each(['queued', 'processing', 'cloning'])('refuses to regenerate a %s dub', async (status) => {
+      await build({ dubbing_projects: chain({ data: { ...row, status }, error: null }) });
+      await expect(service.regenerateDub(USER, 'p-1')).rejects.toThrow(/still running/);
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it('regenerates a completed dub, reserving credits again', async () => {
+      await build({ dubbing_projects: chain({ data: { ...row, status: 'completed' }, error: null }) });
+      await service.regenerateDub(USER, 'p-1');
+      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: -90 });
+      expect(queue.add).toHaveBeenCalled();
+    });
+
+    it('refuses to delete a running dub', async () => {
+      await build({ dubbing_projects: chain({ data: { status: 'processing' }, error: null }) });
+      await expect(service.deleteDub(USER, 'p-1')).rejects.toThrow(/Cancel it before deleting/);
     });
   });
 });

--- a/apps/api/src/dubbing/dubbing.service.ts
+++ b/apps/api/src/dubbing/dubbing.service.ts
@@ -25,6 +25,7 @@ import {
 import {
   getSignedUploadUrl,
   gcsObjectMetadata,
+  moveGcsObject,
   gcsPublicUrl,
   gcsUri,
   deleteGcsObject,
@@ -33,6 +34,17 @@ import {
 
 // Dubbing input is usually a short clip, but a video can be large — cap generously.
 const MAX_DUB_UPLOAD_BYTES = 500 * 1024 * 1024; // 500MB
+
+// Uploads land under this prefix and are MOVED to their permanent path only once the
+// job is accepted. A user who signs an upload and walks away leaves the object here,
+// where the bucket's lifecycle rule deletes it after a day — no sweeper to run.
+// Provision it once (see docs/dubbing-design.md 9.1):
+//   gcloud storage buckets update gs://<bucket> --lifecycle-file=lifecycle.json
+const STAGING_PREFIX = 'staging/';
+
+// A dub in one of these states has a worker (or a queue slot) attached to it: it cannot
+// be regenerated or deleted without orphaning a running job and its reservation.
+const IN_FLIGHT_STATUSES = ['queued', 'processing', 'cloning'];
 
 // The output PUT URL is minted here (at enqueue) but used later by Modal, which only
 // runs after the job leaves the queue and the clone finishes (minutes). Give it a wide
@@ -114,10 +126,46 @@ export class DubbingService {
     );
   }
 
-  /** Same cost the worker will deduct — checked here so we fail before ElevenLabs runs. */
-  private async assertCanAffordDub(userId: string, durationSeconds: number): Promise<void> {
+  /** Credits this dub costs at the current rate — the single place the price is computed. */
+  private dubCost(durationSeconds: number): number {
     const multiplier = this.getEnvNumber('DUBBING_CREDIT_MULTIPLIER', DUBBING_CREDIT_MULTIPLIER);
-    const required = calculateDubbingCreditsByDuration(durationSeconds, multiplier);
+    return calculateDubbingCreditsByDuration(durationSeconds, multiplier);
+  }
+
+  /**
+   * Reserve the dub's cost up front. Deducting at enqueue (rather than after the dub)
+   * is what makes two concurrent dubs safe: `update_user_credits` refuses to go below
+   * zero atomically, so the second one is rejected before ElevenLabs is ever called
+   * instead of completing and then failing to bill. The worker settles the difference
+   * against the vendor's own duration and refunds the whole reservation on failure.
+   */
+  private async reserveCredits(userId: string, credits: number): Promise<void> {
+    const { error } = await this.supabase.rpc('update_user_credits', {
+      user_uuid: userId,
+      credit_change: -credits,
+    });
+    if (error) {
+      throw new ForbiddenException(
+        `This dub costs ${credits} credits and your balance is short. Trim the clip or upgrade your plan.`,
+      );
+    }
+  }
+
+  /** Give a reservation back — used when anything after the deduction fails. */
+  private async refundCredits(userId: string, credits: number): Promise<void> {
+    if (credits <= 0) return;
+    const { error } = await this.supabase.rpc('update_user_credits', {
+      user_uuid: userId,
+      credit_change: credits,
+    });
+    if (error) {
+      this.logger.error(`Failed to refund ${credits} credits to user ${userId}: ${error.message}`);
+    }
+  }
+
+  /** Same cost the worker will settle — checked here so we fail before ElevenLabs runs. */
+  private async assertCanAffordDub(userId: string, durationSeconds: number): Promise<void> {
+    const required = this.dubCost(durationSeconds);
 
     const { data: profile, error } = await this.supabase
       .from('profiles')
@@ -161,15 +209,20 @@ export class DubbingService {
       );
     }
 
+    // Check the balance BEFORE the browser pushes up to 500MB — being told the dub is
+    // unaffordable is much cheaper before the upload than after it.
+    await this.assertCanAffordDub(userId, input.durationSeconds);
+
     const safeName = this.sanitizeFileName(input.filename);
-    const objectName = `${userId}/dubbing/${Date.now()}_${safeName}`;
+    const objectName = `${STAGING_PREFIX}${userId}/dubbing/${Date.now()}_${safeName}`;
     const uploadUrl = await getSignedUploadUrl(this.configService, objectName, input.contentType, this.bucket);
     return { success: true, uploadUrl, objectName, contentType: input.contentType };
   }
 
   /**
-   * Step 2: verify the uploaded object (ownership + real size), create the job row,
-   * and enqueue the dubbing worker. The worker deducts the real (duration-based) cost.
+   * Step 2: verify the uploaded object (ownership + real size), reserve the credits,
+   * create the job row and enqueue the worker. The worker settles the reservation
+   * against the vendor's own duration and refunds it in full if the dub never lands.
    */
   async createDub(input: CreateDubInput, userId: string): Promise<{ projectId: string; jobId: string }> {
     const { objectName, targetLanguage, targetAccent, isVideo, mediaName, durationSeconds } = input;
@@ -180,8 +233,8 @@ export class DubbingService {
     }
     this.assertDurationAllowed(planName, durationSeconds);
 
-    // The signed URL was scoped to this user's prefix — refuse someone else's object.
-    if (!objectName.startsWith(`${userId}/`)) {
+    // The signed URL was scoped to this user's staging prefix — refuse someone else's object.
+    if (!objectName.startsWith(`${STAGING_PREFIX}${userId}/`)) {
       throw new ForbiddenException('Object does not belong to user');
     }
 
@@ -192,18 +245,50 @@ export class DubbingService {
     } catch {
       throw new BadRequestException('Uploaded file not found in storage');
     }
+
+    // From here on the staged object is ours to clean up: every failure path below
+    // deletes it, so a rejected dub never leaves 500MB behind.
+    const discardUpload = () => deleteGcsObject(this.configService, objectName, this.bucket).catch(() => null);
+
     if (size > MAX_DUB_UPLOAD_BYTES) {
-      await deleteGcsObject(this.configService, objectName, this.bucket).catch(() => null);
+      await discardUpload();
       throw new PayloadTooLargeException('Uploaded file exceeds the dubbing upload limit.');
     }
 
-    // Precheck the FULL duration-based cost, not just a one-second floor: the worker
-    // deducts the whole amount after ElevenLabs has already run, so a short balance
-    // discovered there costs us the dub and shows the user a failure they can't act on.
-    await this.assertCanAffordDub(userId, durationSeconds);
+    // Precheck the FULL duration-based cost, not just a one-second floor, so the user
+    // gets a clear message rather than the bare "balance is short" from the reservation.
+    try {
+      await this.assertCanAffordDub(userId, durationSeconds);
+    } catch (error) {
+      await discardUpload();
+      throw error;
+    }
 
-    const publicUrl = gcsPublicUrl(this.configService, objectName, this.bucket);
-    const inputGsUri = gcsUri(this.configService, objectName, this.bucket);
+    // Promote the staged object to its permanent path. Anything still in staging is,
+    // by definition, an upload nobody claimed.
+    const finalObject = objectName.slice(STAGING_PREFIX.length);
+    try {
+      await moveGcsObject(this.configService, objectName, finalObject, this.bucket);
+    } catch (error: any) {
+      await discardUpload();
+      this.logger.error(`Failed to promote staged dub upload for user ${userId}: ${error?.message}`);
+      throw new InternalServerErrorException('Failed to store the uploaded media');
+    }
+
+    const cleanupMedia = () => deleteGcsObject(this.configService, finalObject, this.bucket).catch(() => null);
+
+    // Take the money now. Atomic and floored at zero, so two dubs started at once can
+    // never both pass — the second is rejected here instead of after ElevenLabs ran.
+    const reservedCredits = this.dubCost(durationSeconds);
+    try {
+      await this.reserveCredits(userId, reservedCredits);
+    } catch (error) {
+      await cleanupMedia();
+      throw error;
+    }
+
+    const publicUrl = gcsPublicUrl(this.configService, finalObject, this.bucket);
+    const inputGsUri = gcsUri(this.configService, finalObject, this.bucket);
     const projectId = crypto.randomUUID();
 
     const { error: insertError } = await this.supabase.from('dubbing_projects').insert({
@@ -218,23 +303,19 @@ export class DubbingService {
       media_name: mediaName,
       duration_seconds: durationSeconds,
       status: 'queued',
-      credits_consumed: 0,
+      credits_consumed: reservedCredits,
     });
     if (insertError) {
-      await deleteGcsObject(this.configService, objectName, this.bucket).catch(() => null);
+      await this.refundCredits(userId, reservedCredits);
+      await cleanupMedia();
       this.logger.error(`Failed to create dubbing project for user ${userId}: ${insertError.message}`);
       throw new InternalServerErrorException('Failed to create dubbing project');
     }
 
-    const output = await this.signOutputUpload(projectId, isVideo);
-
-    const bullJobId = `dubbing-${userId}-${Date.now()}`;
-    await this.queue.add(
-      'dubbing',
-      {
+    try {
+      const jobId = await this.enqueue({
         userId,
         projectId,
-        bullJobId,
         inputGsUri,
         inputUrl: publicUrl,
         mimeType: contentType,
@@ -243,14 +324,48 @@ export class DubbingService {
         targetAccent,
         durationSeconds,
         planName,
-        ...output,
-      },
-      { jobId: bullJobId },
-    );
+        reservedCredits,
+      });
+      return { projectId, jobId };
+    } catch (error: any) {
+      await this.refundCredits(userId, reservedCredits);
+      await this.supabase
+        .from('dubbing_projects')
+        .update({ status: 'failed', error_message: 'Could not be queued. Please try again.', credits_consumed: 0 })
+        .eq('project_id', projectId);
+      this.logger.error(`Failed to enqueue dub ${projectId}: ${error?.message}`);
+      throw new InternalServerErrorException('Failed to queue the dubbing job');
+    }
+  }
 
-    await this.supabase.from('dubbing_projects').update({ job_id: bullJobId }).eq('project_id', projectId);
+  /**
+   * Mint the output URL, push the job and record its id.
+   *
+   * The job id is a random UUID, not `dubbing-{userId}-{timestamp}`: the SSE status
+   * route is unauthenticated (EventSource cannot send an Authorization header), so the
+   * id is the only thing standing between a job's progress and a stranger. A predictable
+   * id built from a user id and a millisecond is guessable; a UUID is not.
+   */
+  private async enqueue(data: {
+    userId: string;
+    projectId: string;
+    inputGsUri: string;
+    inputUrl: string;
+    mimeType: string;
+    isVideo: boolean;
+    targetLanguage: string;
+    targetAccent?: string | null;
+    durationSeconds: number;
+    planName: string | null;
+    reservedCredits: number;
+  }): Promise<string> {
+    const output = await this.signOutputUpload(data.projectId, data.isVideo);
+    const bullJobId = `dubbing-${crypto.randomUUID()}`;
 
-    return { projectId, jobId: bullJobId };
+    await this.queue.add('dubbing', { ...data, bullJobId, ...output }, { jobId: bullJobId });
+    await this.supabase.from('dubbing_projects').update({ job_id: bullJobId }).eq('project_id', data.projectId);
+
+    return bullJobId;
   }
 
   /**
@@ -285,13 +400,18 @@ export class DubbingService {
 
     const { data: row, error } = await this.supabase
       .from('dubbing_projects')
-      .select('input_gs_uri, input_url, target_language, target_accent, is_video, duration_seconds')
+      .select('input_gs_uri, input_url, target_language, target_accent, is_video, duration_seconds, status')
       .eq('user_id', userId)
       .eq('project_id', projectId)
       .single();
     if (error || !row) throw new NotFoundException('Dubbing project not found');
     if (!row.input_gs_uri || !row.input_url || !row.duration_seconds) {
       throw new BadRequestException('This dub is missing its source media and cannot be regenerated.');
+    }
+    // A second run while the first is still going would charge twice and race the same
+    // output object — the in-flight run has to finish or be cancelled first.
+    if (IN_FLIGHT_STATUSES.includes(row.status)) {
+      throw new BadRequestException('This dub is still running. Wait for it to finish, or cancel it first.');
     }
 
     // Re-check the cap: a downgrade since the original dub must not let a long clip
@@ -309,22 +429,20 @@ export class DubbingService {
 
     await this.assertCanAffordDub(userId, Number(row.duration_seconds));
 
+    const reservedCredits = this.dubCost(Number(row.duration_seconds));
+    await this.reserveCredits(userId, reservedCredits);
+
     // Reset the row in place so the same detail page reflects the new run.
     await this.supabase
       .from('dubbing_projects')
-      .update({ status: 'queued', dubbed_url: null, error_message: null, credits_consumed: 0 })
+      .update({ status: 'queued', dubbed_url: null, error_message: null, credits_consumed: reservedCredits })
       .eq('project_id', projectId)
       .eq('user_id', userId);
 
-    const output = await this.signOutputUpload(projectId, row.is_video);
-
-    const bullJobId = `dubbing-${userId}-${Date.now()}`;
-    await this.queue.add(
-      'dubbing',
-      {
+    try {
+      const jobId = await this.enqueue({
         userId,
         projectId,
-        bullJobId,
         inputGsUri: row.input_gs_uri,
         inputUrl: row.input_url,
         mimeType: contentType,
@@ -333,19 +451,27 @@ export class DubbingService {
         targetAccent: row.target_accent,
         durationSeconds: Number(row.duration_seconds),
         planName,
-        ...output,
-      },
-      { jobId: bullJobId },
-    );
-
-    await this.supabase.from('dubbing_projects').update({ job_id: bullJobId }).eq('project_id', projectId);
-
-    return { projectId, jobId: bullJobId };
+        reservedCredits,
+      });
+      return { projectId, jobId };
+    } catch (error: any) {
+      await this.refundCredits(userId, reservedCredits);
+      await this.supabase
+        .from('dubbing_projects')
+        .update({ status: 'failed', error_message: 'Could not be queued. Please try again.', credits_consumed: 0 })
+        .eq('project_id', projectId);
+      this.logger.error(`Failed to enqueue regenerated dub ${projectId}: ${error?.message}`);
+      throw new InternalServerErrorException('Failed to queue the dubbing job');
+    }
   }
 
   /**
    * Mid-run cancellation (train-ai pattern): a queued job is removed outright;
    * an active one gets a Redis flag the worker checks between pipeline stages.
+   *
+   * Refunds are split by who owns the job at that moment: a job removed from the queue
+   * never reaches the worker, so the API gives the reservation back here; an active one
+   * is refunded by the worker when it aborts. Exactly one of the two runs.
    */
   async stopDub(userId: string, jobId: string): Promise<{ message: string }> {
     const job = await this.queue.getJob(jobId);
@@ -356,11 +482,14 @@ export class DubbingService {
     const state = await job.getState();
 
     if (state === 'waiting' || state === 'delayed') {
+      // remove() throws if the job went active in the meantime, so reaching the next
+      // line means the worker never picked it up and the refund cannot double up.
       await job.remove();
+      await this.refundCredits(userId, Number(job.data?.reservedCredits ?? 0));
       // Mark the row too — otherwise it sits 'queued' forever.
       await this.supabase
         .from('dubbing_projects')
-        .update({ status: 'failed', error_message: 'Cancelled by user' })
+        .update({ status: 'failed', error_message: 'Cancelled by user', credits_consumed: 0 })
         .eq('project_id', job.data.projectId)
         .eq('user_id', userId);
       return { message: 'Dubbing cancelled' };
@@ -369,7 +498,9 @@ export class DubbingService {
     if (state === 'active') {
       const client = await this.queue.client;
       await client.set(`${DUBBING_CANCEL_PREFIX}${jobId}`, '1', 'EX', 3600);
-      return { message: 'Cancellation requested' };
+      // "Requested", not "cancelled": the worker only checks between stages, so a run
+      // already past its last checkpoint will finish and charge normally.
+      return { message: 'Cancellation requested — it will stop at the next step if it has not already finished.' };
     }
 
     return { message: 'Job already finished' };
@@ -413,6 +544,18 @@ export class DubbingService {
   }
 
   async deleteDub(userId: string, projectId: string): Promise<void> {
+    // Deleting the row out from under a running worker makes its status writes fail and
+    // strands the reservation — make the user cancel first.
+    const { data: existing } = await this.supabase
+      .from('dubbing_projects')
+      .select('status')
+      .eq('user_id', userId)
+      .eq('project_id', projectId)
+      .maybeSingle();
+    if (existing && IN_FLIGHT_STATUSES.includes(existing.status)) {
+      throw new BadRequestException('This dub is still running. Cancel it before deleting.');
+    }
+
     const { data, error } = await this.supabase
       .from('dubbing_projects')
       .delete()

--- a/apps/api/src/guards/onboarded.guard.spec.ts
+++ b/apps/api/src/guards/onboarded.guard.spec.ts
@@ -1,0 +1,64 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { OnboardedGuard } from './onboarded.guard';
+import { SupabaseService } from '../supabase/supabase.service';
+
+type Profile = { ai_trained: boolean; youtube_connected: boolean } | null;
+
+function makeGuard(profile: Profile, error: unknown = null) {
+  const chain = {
+    select: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    single: jest.fn(async () => ({ data: profile, error })),
+  };
+  const supabase = { getClient: () => ({ from: jest.fn(() => chain) }) };
+  return new OnboardedGuard(supabase as unknown as SupabaseService);
+}
+
+const ctx = (userId?: string) =>
+  ({
+    switchToHttp: () => ({ getRequest: () => ({ user: userId ? { id: userId } : undefined }) }),
+  }) as unknown as ExecutionContext;
+
+describe('OnboardedGuard', () => {
+  it('lets a fully onboarded user through', async () => {
+    const guard = makeGuard({ ai_trained: true, youtube_connected: true });
+    await expect(guard.canActivate(ctx('u1'))).resolves.toBe(true);
+  });
+
+  // The bug this guard exists for: dubbing charged users who had neither.
+  it('blocks when both are missing, and names both', async () => {
+    const guard = makeGuard({ ai_trained: false, youtube_connected: false });
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow(
+      'This feature requires AI training and a connected YouTube channel.',
+    );
+  });
+
+  // Requirement is AND, not OR — one of the two is not enough.
+  it('blocks when only training is missing', async () => {
+    const guard = makeGuard({ ai_trained: false, youtube_connected: true });
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow('This feature requires AI training.');
+  });
+
+  it('blocks when only YouTube is missing', async () => {
+    const guard = makeGuard({ ai_trained: true, youtube_connected: false });
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow(
+      'This feature requires a connected YouTube channel.',
+    );
+  });
+
+  // Null columns on an older profile row must fail closed, not sail through.
+  it('fails closed on null flags', async () => {
+    const guard = makeGuard({ ai_trained: null, youtube_connected: null } as never);
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects a missing profile', async () => {
+    const guard = makeGuard(null, { message: 'no rows' });
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow('Profile not found');
+  });
+
+  it('rejects an unauthenticated request', async () => {
+    const guard = makeGuard({ ai_trained: true, youtube_connected: true });
+    await expect(guard.canActivate(ctx())).rejects.toThrow('Authentication required');
+  });
+});

--- a/apps/api/src/guards/onboarded.guard.ts
+++ b/apps/api/src/guards/onboarded.guard.ts
@@ -1,0 +1,42 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { SupabaseService } from '../supabase/supabase.service';
+
+/**
+ * Every credit-spending feature requires a trained AI *and* a connected YouTube
+ * channel. This lived as a hand-written check inside subtitle and ideation only,
+ * which is how dubbing and video-generation ended up chargeable by users who had
+ * neither. Applying it as a guard makes the requirement declarative: a new route
+ * either lists it in @UseGuards or it deliberately doesn't need it.
+ *
+ * Order matters — it must follow SupabaseAuthGuard, which is what sets request.user.
+ */
+@Injectable()
+export class OnboardedGuard implements CanActivate {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId = request.user?.id;
+    if (!userId) throw new ForbiddenException('Authentication required');
+
+    const { data: profile, error } = await this.supabaseService
+      .getClient()
+      .from('profiles')
+      .select('ai_trained, youtube_connected')
+      .eq('user_id', userId)
+      .single();
+
+    if (error || !profile) throw new ForbiddenException('Profile not found');
+
+    const missing: string[] = [];
+    if (!profile.ai_trained) missing.push('AI training');
+    if (!profile.youtube_connected) missing.push('a connected YouTube channel');
+    if (missing.length > 0) {
+      throw new ForbiddenException(`This feature requires ${missing.join(' and ')}.`);
+    }
+
+    // Downstream services re-read the profile for credits; these two are already
+    // proven here, so nothing below needs to check them again.
+    return true;
+  }
+}

--- a/apps/api/src/ideation/ideation.controller.ts
+++ b/apps/api/src/ideation/ideation.controller.ts
@@ -8,6 +8,7 @@ import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import type { Observable } from 'rxjs';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
 import { getUserId } from '../common/get-user-id';
 import { createJobSSE } from '../common/sse';
@@ -22,7 +23,7 @@ export class IdeationController {
   ) {}
 
   @Post()
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue ideation job' })
   async create(
@@ -33,7 +34,7 @@ export class IdeationController {
   }
 
   @Post('surprise')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Suggest a niche focus from the creator\'s trained style' })
   async surprise(@Req() req: AuthRequest) {

--- a/apps/api/src/ideation/ideation.service.ts
+++ b/apps/api/src/ideation/ideation.service.ts
@@ -131,14 +131,11 @@ export class IdeationService {
 
     const { data: profile, error: profileError } = await this.supabase
       .from('profiles')
-      .select('credits, ai_trained')
+      .select('credits')
       .eq('user_id', userId)
       .single();
 
     if (profileError || !profile) throw new NotFoundException('Profile not found');
-    if (!profile.ai_trained) {
-      throw new ForbiddenException('AI training is required before generating ideas. Train your AI first.');
-    }
     const ideationMultiplier = this.getEnvNumber(
       'IDEATION_CREDIT_MULTIPLIER',
       IDEATION_CREDIT_MULTIPLIER,

--- a/apps/api/src/script/script.controller.ts
+++ b/apps/api/src/script/script.controller.ts
@@ -9,6 +9,7 @@ import { Queue } from 'bullmq';
 import type { Response } from 'express';
 import type { Observable } from 'rxjs';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { CreateScriptSchema, type CreateScriptInput } from '@repo/validation';
 import { getUserId } from '../common/get-user-id';
@@ -26,7 +27,7 @@ export class ScriptController {
   ) {}
 
   @Post('generate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue script generation (multipart: fields + optional files)' })
   @ApiMultipartForm({

--- a/apps/api/src/story-builder/story-builder.controller.ts
+++ b/apps/api/src/story-builder/story-builder.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiBody } from '@nestjs
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { CreateStoryBuilderSchema, type CreateStoryBuilderInput } from '@repo/validation';
 import type { Observable } from 'rxjs';
@@ -20,7 +21,7 @@ export class StoryBuilderController {
   ) {}
 
   @Post('generate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue story-builder job' })
   @ApiBody({

--- a/apps/api/src/subtitle/subtitle.controller.ts
+++ b/apps/api/src/subtitle/subtitle.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiBody } from '@nestjs
 import { createReadStream } from 'fs';
 import { SubtitleService } from './subtitle.service';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import type { Response } from 'express';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
@@ -31,6 +32,7 @@ export class SubtitleController {
   constructor(private readonly subtitleService: SubtitleService) { }
 
   @Post()
+  @UseGuards(OnboardedGuard)
   @ApiOperation({ summary: 'Create subtitle record' })
   @ApiBody({
     schema: {
@@ -75,6 +77,7 @@ export class SubtitleController {
   }
 
   @Post('upload/sign')
+  @UseGuards(OnboardedGuard)
   @ApiOperation({ summary: 'Get a signed URL to upload the video directly to storage' })
   @ApiBody({
     schema: {
@@ -99,6 +102,7 @@ export class SubtitleController {
   }
 
   @Post('upload/finalize')
+  @UseGuards(OnboardedGuard)
   @ApiOperation({ summary: 'Create the subtitle job after the direct upload completes' })
   @ApiBody({
     schema: {
@@ -209,6 +213,7 @@ export class SubtitleController {
   }
 
   @Post('burn')
+  @UseGuards(OnboardedGuard)
   @ApiOperation({ summary: 'Burn subtitles into video (returns MP4 stream)' })
   @ApiBody({
     schema: {

--- a/apps/api/src/subtitle/subtitle.service.ts
+++ b/apps/api/src/subtitle/subtitle.service.ts
@@ -68,18 +68,13 @@ export class SubtitleService {
     try {
       const { data: profileData, error: profileError } = await this.supabaseService.getClient()
         .from('profiles')
-        .select('credits, ai_trained, youtube_connected')
+        .select('credits')
         .eq('user_id', userId)
         .single();
 
       if (profileError || !profileData) {
         await this.logErrorToDB('Profile not found or profile fetch failed', subtitleId);
         throw new NotFoundException('Profile not found');
-      }
-
-      if (!profileData.ai_trained && !profileData.youtube_connected) {
-        await this.logErrorToDB('AI training and YouTube connection are required', subtitleId);
-        throw new ForbiddenException('AI training and YouTube connection are required');
       }
 
       const subtitleMultiplier = this.getEnvNumber(

--- a/apps/api/src/thumbnail/thumbnail.controller.ts
+++ b/apps/api/src/thumbnail/thumbnail.controller.ts
@@ -16,6 +16,7 @@ import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { CreateThumbnailSchema, type CreateThumbnailInput } from '@repo/validation';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
@@ -34,7 +35,7 @@ export class ThumbnailController {
   ) { }
 
   @Post('generate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue thumbnail generation (optional reference + face images)' })
   @ApiMultipartForm({

--- a/apps/api/src/utils/gcs.ts
+++ b/apps/api/src/utils/gcs.ts
@@ -123,6 +123,23 @@ export async function gcsObjectMetadata(
   return { size: Number(meta.size ?? 0), contentType: meta.contentType ?? 'application/octet-stream' };
 }
 
+/**
+ * Server-side move within a bucket (copy + delete, the bytes never transit this process).
+ * Used to promote a staged upload into its permanent path once the job is accepted —
+ * anything left in the staging prefix is an abandoned upload and expires on its own via
+ * the bucket lifecycle rule.
+ */
+export async function moveGcsObject(
+  configService: ConfigService,
+  fromObject: string,
+  toObject: string,
+  bucket?: string,
+): Promise<void> {
+  const storage = await getStorage(configService);
+  const b = storage.bucket(bucket ?? getBucketName(configService));
+  await b.file(fromObject).move(b.file(toObject));
+}
+
 export async function deleteGcsObject(configService: ConfigService, objectName: string, bucket?: string): Promise<void> {
   const storage = await getStorage(configService);
   await storage

--- a/apps/api/src/video-generation/video-generation.controller.ts
+++ b/apps/api/src/video-generation/video-generation.controller.ts
@@ -13,6 +13,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiBody } from '@nestjs
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import {
   CreateVideoGenerationSchema,
@@ -45,7 +46,7 @@ export class VideoGenerationController {
   }
 
   @Post('surprise')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Generate an on-brand video prompt from the creator\'s trained style' })
   async surprise(
@@ -56,7 +57,7 @@ export class VideoGenerationController {
   }
 
   @Post('generate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue an Omni Flash video generation (Pro/Business/Scale plans only)' })
   @ApiBody({
@@ -87,7 +88,7 @@ export class VideoGenerationController {
   }
 
   @Post(':id/edit')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Statefully edit a finished video (Omni previous_interaction_id)' })
   @ApiParam({ name: 'id' })

--- a/apps/web/app/dashboard/dubbing/new/page.tsx
+++ b/apps/web/app/dashboard/dubbing/new/page.tsx
@@ -110,6 +110,7 @@ export default function NewDubbing() {
     isLoading,
     allowed,
     accessLoading,
+    maxDurationSeconds,
     canCancel,
     cancelDub,
     handleFileChange,
@@ -141,7 +142,7 @@ export default function NewDubbing() {
       e.preventDefault();
       setIsDragging(false);
       if (isLoading) return;
-      handleFileSelect(e.dataTransfer.files?.[0]);
+      void handleFileSelect(e.dataTransfer.files?.[0]);
     },
     [handleFileSelect, isLoading],
   );
@@ -300,7 +301,7 @@ export default function NewDubbing() {
                         Dub Your Media
                       </CardTitle>
                       <CardDescription>
-                        Translate your audio or video into one of 21 languages while keeping the original voice characteristics.
+                        Translate your audio or video into one of 29 languages while keeping the original voice characteristics.
                       </CardDescription>
                     </CardHeader>
 
@@ -368,7 +369,9 @@ export default function NewDubbing() {
                           <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[11px] text-slate-400 uppercase tracking-widest font-bold">
                             <span>MP3 · WAV · MP4 · MOV</span>
                             <span className="hidden sm:inline w-1 h-1 bg-slate-300 dark:bg-slate-600 rounded-full" />
-                            <span>Max 500MB · 45 min</span>
+                            {/* The plan's real cap, not a generic one — a Starter user needs to
+                                know about the 60s limit before picking a file, not after. */}
+                            <span>Max 500MB · {maxDurationSeconds ? `${maxDurationSeconds}s per clip` : "45 min"}</span>
                           </div>
                         </Label>
                         <Input

--- a/apps/web/hooks/useDubbing.ts
+++ b/apps/web/hooks/useDubbing.ts
@@ -24,7 +24,14 @@ function getMediaDuration(file: File): Promise<number> {
     el.preload = "metadata";
     el.onloadedmetadata = () => {
       URL.revokeObjectURL(el.src);
-      resolve(el.duration || 0);
+      // Header-less VBR/WebM reports Infinity, which JSON.stringify sends as null and
+      // the API then rejects as a missing duration — catch it here with a message that
+      // says what to do about it.
+      if (!Number.isFinite(el.duration) || el.duration <= 0) {
+        reject(new Error("Could not read this file's length. Try re-exporting it as MP3 or MP4."));
+        return;
+      }
+      resolve(el.duration);
     };
     el.onerror = () => {
       URL.revokeObjectURL(el.src);
@@ -39,6 +46,9 @@ export function useDubbing() {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [mediaFile, setMediaFile] = useState<File | null>(null);
+  // Measured once, when the file is picked — so the plan cap is enforced before the
+  // user fills in the rest of the form, not after they press Dub.
+  const [mediaDuration, setMediaDuration] = useState<number | null>(null);
   const [isVideo, setIsVideo] = useState(false);
   const [targetLanguage, setTargetLanguage] = useState("");
   const [targetAccent, setTargetAccent] = useState("");
@@ -83,7 +93,7 @@ export function useDubbing() {
   );
 
   // Shared by the file input and the drag-and-drop zone.
-  const handleFileSelect = useCallback((file: File | null | undefined) => {
+  const handleFileSelect = useCallback(async (file: File | null | undefined) => {
     if (!file) return;
 
     if (!/^(audio|video)\//.test(file.type)) {
@@ -95,19 +105,38 @@ export function useDubbing() {
       return;
     }
 
+    let duration: number;
+    try {
+      duration = await getMediaDuration(file);
+    } catch (error) {
+      toast.error("Unreadable file", {
+        description: error instanceof Error ? error.message : "The file may be corrupt.",
+      });
+      return;
+    }
+
+    if (maxDurationSeconds !== null && duration > maxDurationSeconds) {
+      toast.error(`Clip is too long for your plan`, {
+        description: `Your plan dubs clips up to ${maxDurationSeconds}s. This one is ${Math.round(duration)}s — trim it, or upgrade for unlimited length.`,
+      });
+      return;
+    }
+
     setIsVideo(file.type.startsWith("video/"));
     setMediaFile(file);
+    setMediaDuration(duration);
     setDubbedResult(null);
     setProgress({ state: "idle", progress: 0, message: "" });
-  }, []);
+  }, [maxDurationSeconds]);
 
   const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    handleFileSelect(e.target.files?.[0]);
+    void handleFileSelect(e.target.files?.[0]);
     if (fileInputRef.current) fileInputRef.current.value = ""; // allow re-selecting the same file
   }, [handleFileSelect]);
 
   const resetForm = useCallback(() => {
     setMediaFile(null);
+    setMediaDuration(null);
     setTargetLanguage("");
     setTargetAccent("");
     setMediaName("");
@@ -127,8 +156,8 @@ export function useDubbing() {
     let eventSource: EventSource | null = null;
 
     try {
-      const durationSeconds = await getMediaDuration(mediaFile);
-      if (!durationSeconds) throw new Error("Could not determine media duration.");
+      // Measured at file-select; re-read only if that somehow did not stick.
+      const durationSeconds = mediaDuration ?? (await getMediaDuration(mediaFile));
 
       // Fail before the upload rather than after it — the server enforces this too,
       // this just saves the user pushing a file to GCS that will be rejected.
@@ -222,7 +251,7 @@ export function useDubbing() {
       updateProgress("failed", 0, message);
       toast.error("Error dubbing media", { description: message });
     }
-  }, [mediaFile, targetLanguage, targetAccent, isVideo, mediaName, session, updateProgress, maxDurationSeconds]);
+  }, [mediaFile, mediaDuration, targetLanguage, targetAccent, isVideo, mediaName, session, updateProgress, maxDurationSeconds]);
 
   /** Cancel the in-flight dub: queued jobs stop instantly, active ones abort between stages. */
   const cancelDub = useCallback(async () => {
@@ -246,6 +275,7 @@ export function useDubbing() {
   return {
     fileInputRef,
     mediaFile,
+    mediaDuration,
     isVideo,
     targetLanguage,
     setTargetLanguage,

--- a/docs/dubbing-design.md
+++ b/docs/dubbing-design.md
@@ -269,7 +269,23 @@ gcloud storage buckets add-iam-policy-binding gs://creator-ai-dubbing \
   --member="serviceAccount:<vertex-sa>@creator-ai-498712.iam.gserviceaccount.com" \
   --role=roles/storage.objectAdmin
 
-# 4. CORS so the browser can PUT to the signed URL
+# 4. Expire abandoned uploads. The API signs uploads into `staging/` and MOVES the
+#    object to its permanent path only once the job is accepted, so anything left
+#    under `staging/` is an upload nobody claimed. One day is well clear of the
+#    seconds between the PUT finishing and POST /dubbing.
+#    NOTE: --lifecycle-file REPLACES every rule on the bucket. Check what is there
+#    first and include those rules in the file if any exist.
+gcloud storage buckets describe gs://creator-ai-dubbing --format="default(lifecycle_config)"
+
+cat > lifecycle.json <<'EOF'
+{"lifecycle": {"rule": [
+  {"action": {"type": "Delete"},
+   "condition": {"age": 1, "matchesPrefix": ["staging/"]}}
+]}}
+EOF
+gcloud storage buckets update gs://creator-ai-dubbing --lifecycle-file=lifecycle.json
+
+# 5. CORS so the browser can PUT to the signed URL
 cat > cors.json <<'EOF'
 [{"origin": ["http://localhost:3000"], "method": ["PUT", "GET"],
   "responseHeader": ["Content-Type"], "maxAgeSeconds": 3600}]

--- a/packages/supabase/migrations/20260821000000_starter_subscription_on_signup.sql
+++ b/packages/supabase/migrations/20260821000000_starter_subscription_on_signup.sql
@@ -1,0 +1,65 @@
+-- =====================================================================
+-- Give every new user their Starter subscription row at signup.
+-- ---------------------------------------------------------------------
+-- Until now handle_new_user() created only the profile, and the Starter
+-- subscriptions row was created lazily as a side effect of the first
+-- GET /billing/info (billing.service.ts getBillingInfo). Everything that
+-- resolves a user's plan reads `subscriptions` joined to `plans` -- dubbing's
+-- canDub(), video generation, research limits -- so on a brand-new account any
+-- of those can run BEFORE billing/info has been called and see no plan at all.
+-- Dubbing then fails closed and shows an upgrade wall to a user whose plan
+-- allows dubbing; a refresh "fixes" it, which is why it never reproduces.
+--
+-- Fixing it at the signup trigger closes it once for every reader instead of
+-- teaching each feature to guess at the missing row. getBillingInfo's lazy
+-- insert stays as-is: it is now a no-op for new users and still backfills any
+-- old account this migration cannot see.
+--
+-- Starter = the free plan (price 0). Prefer price over name so a rename cannot
+-- break signup (same rule downgrade_expired_subscriptions and
+-- billing.service.getStarterPlan use).
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  starter_id uuid;
+begin
+  insert into public.profiles (id, user_id, name, email, ai_trained)
+  values (new.id, new.id, new.raw_user_meta_data->>'name', new.email, false);
+
+  select id into starter_id
+  from public.plans
+  where price_monthly = 0
+  order by credits_monthly desc
+  limit 1;
+
+  -- No free plan configured is a misconfiguration, not a reason to fail signup.
+  if starter_id is null then
+    raise log 'handle_new_user: no free/Starter plan found, skipping subscription for %', new.id;
+    return new;
+  end if;
+
+  insert into public.subscriptions (user_id, plan_id, status, current_period_start, current_period_end)
+  values (new.id, starter_id, 'active', now(), null);
+
+  return new;
+end;
+$function$;
+
+-- Backfill: existing accounts that never loaded billing/info have no row either.
+INSERT INTO public.subscriptions (user_id, plan_id, status, current_period_start, current_period_end)
+SELECT p.user_id, s.id, 'active', now(), null
+FROM public.profiles p
+CROSS JOIN LATERAL (
+  SELECT id FROM public.plans WHERE price_monthly = 0 ORDER BY credits_monthly DESC LIMIT 1
+) s
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.subscriptions sub
+  WHERE sub.user_id = p.user_id
+    AND sub.status IN ('active', 'on_trial', 'past_due')
+);

--- a/packages/validations/src/consts/dubbing.check.ts
+++ b/packages/validations/src/consts/dubbing.check.ts
@@ -77,10 +77,25 @@ assert.equal(
   }).success,
   false, // duration must be positive
 );
+// A header-less VBR/WebM file makes the browser report Infinity. It is "positive", so
+// only .finite() stops it from being priced and JSON-serialised into a null.
+assert.equal(
+  SignDubUploadSchema.safeParse({
+    filename: 'a.mp3', contentType: 'audio/mpeg', fileSize: 1000, isVideo: false, durationSeconds: Infinity,
+  }).success,
+  false,
+);
+assert.equal(
+  CreateDubSchema.safeParse({
+    objectName: 'staging/user-1/dubbing/123_a.mp3', targetLanguage: 'es', isVideo: false, mediaName: 'x',
+    durationSeconds: Infinity,
+  }).success,
+  false,
+);
 
 // Create schema: objectName-based (no raw client URL); numbers coerce, booleans don't.
 const created = CreateDubSchema.parse({
-  objectName: 'user-1/dubbing/123_a.mp3',
+  objectName: 'staging/user-1/dubbing/123_a.mp3',
   targetLanguage: 'es',
   isVideo: false,
   mediaName: 'My clip',

--- a/packages/validations/src/schema/dubbing.schema.ts
+++ b/packages/validations/src/schema/dubbing.schema.ts
@@ -10,7 +10,9 @@ export const SignDubUploadSchema = z.object({
   fileSize: z.coerce.number().int().positive(),
   // Real boolean only — z.coerce.boolean() would turn the string "false" into true.
   isVideo: z.boolean(),
-  durationSeconds: z.coerce.number().positive({ message: 'Duration is required' }),
+  // .finite(): a browser that can't read a header reports Infinity for the duration,
+  // which JSON.stringify turns into null — reject it here rather than pricing off it.
+  durationSeconds: z.coerce.number().positive({ message: 'Duration is required' }).finite(),
 });
 
 // Step 2: after the browser uploaded to GCS, create the dubbing job from the
@@ -21,7 +23,7 @@ export const CreateDubSchema = z.object({
   targetAccent: z.string().max(40).optional(),
   isVideo: z.boolean(),
   mediaName: z.string().min(1, { message: 'Media name is required' }).max(100),
-  durationSeconds: z.coerce.number().positive({ message: 'Duration is required' }),
+  durationSeconds: z.coerce.number().positive({ message: 'Duration is required' }).finite(),
 });
 
 // Output/response schema

--- a/packages/workers/src/processor/dubbing.processor.ts
+++ b/packages/workers/src/processor/dubbing.processor.ts
@@ -59,6 +59,7 @@ interface DubJobData {
   targetAccent?: string | null;
   durationSeconds: number;
   planName?: string | null;   // for the plan duration cap, re-checked against the vendor's own reading
+  reservedCredits: number;    // already deducted at enqueue — this job settles or refunds it
   outputPutUrl: string;       // signed PUT URL — the dubbed file goes straight to GCS
   outputContentType: string;  // must match the URL's signed Content-Type (video/mp4 | audio/mpeg)
   outputPublicUrl: string;    // public GCS URL of the result, recorded once the upload confirms
@@ -90,8 +91,13 @@ export class DubbingProcessor extends WorkerHost {
   async process(job: Job<DubJobData>): Promise<{ dubbedUrl: string }> {
     const {
       userId, projectId, inputUrl, isVideo, targetLanguage, targetAccent,
-      durationSeconds, planName, outputPutUrl, outputContentType, outputPublicUrl,
+      durationSeconds, planName, reservedCredits, outputPutUrl, outputContentType, outputPublicUrl,
     } = job.data;
+
+    // Credits were taken at enqueue. This tracks what the user is currently out of
+    // pocket so every exit path — failure, cancellation, a re-priced dub — settles
+    // against the real number instead of assuming the reservation was right.
+    let chargedCredits = reservedCredits ?? 0;
 
     await job.updateProgress(0);
     await job.log('Starting dubbing...');
@@ -122,6 +128,17 @@ export class DubbingProcessor extends WorkerHost {
         );
       }
 
+      // Re-price against the vendor's reading too, not just the cap. The browser sets
+      // the reservation and a tampered `durationSeconds` would otherwise buy a
+      // 45-minute dub for one second's worth of credits.
+      if (expectedDurationSec) {
+        chargedCredits = await this.settleCredits(userId, chargedCredits, expectedDurationSec, job);
+        await this.updateJob(projectId, { credits_consumed: chargedCredits });
+      } else {
+        // No independent reading available: the browser's number stands as the price.
+        this.logger.warn(`Dub ${projectId}: ElevenLabs returned no duration — priced on the client's ${durationSeconds}s.`);
+      }
+
       await this.throwIfCancelled(job.id!);
       await this.updateJob(projectId, { status: 'cloning' });
       await job.log('Cloning your voice and generating the dub...');
@@ -138,36 +155,28 @@ export class DubbingProcessor extends WorkerHost {
       await job.updateProgress(80);
 
       // The result is now in GCS at the pre-signed location.
-      // Last cancellation window — after this we charge credits and persist.
+      // Last cancellation window — stopping here refunds and discards a finished dub.
       await this.throwIfCancelled(job.id!);
       const dubbedUrl = outputPublicUrl;
       await job.updateProgress(90);
 
-      // 5. Deduct duration-based credits — only after a successful dub.
-      const multiplier = this.getEnvNumber('DUBBING_CREDIT_MULTIPLIER', DUBBING_CREDIT_MULTIPLIER);
-      const creditsConsumed = calculateDubbingCreditsByDuration(durationSeconds, multiplier);
-
-      const { error: creditError } = await this.supabase.rpc('update_user_credits', {
-        user_uuid: userId,
-        credit_change: -creditsConsumed,
-      });
-      if (creditError) {
-        this.logger.error(`Credit deduction failed for user ${userId}: ${creditError.message}`);
-        await this.updateJob(projectId, { status: 'failed', error_message: 'Insufficient credits' });
-        throw new Error('Insufficient credits. Please upgrade your plan.');
-      }
-
+      // 5. Credits were already settled above — nothing can fail between a finished dub
+      //    and the user having it, which is the whole point of reserving at enqueue.
       await this.updateJob(projectId, {
         status: 'completed',
         dubbed_url: dubbedUrl,
-        credits_consumed: creditsConsumed,
+        credits_consumed: chargedCredits,
       });
       await job.updateProgress(100);
-      await job.log(`Done! ${creditsConsumed} credits deducted.`);
+      await job.log(`Done! ${chargedCredits} credits deducted.`);
 
       return { dubbedUrl };
     } catch (error: any) {
       const cancelled = error instanceof DubbingCancelledError;
+      // Nothing was delivered, so nothing is owed — hand the reservation back before
+      // anything else, including before the error is reported.
+      await this.refundCredits(userId, chargedCredits);
+      chargedCredits = 0;
       await job.log(cancelled ? 'Cancelled by user.' : `Fatal error: ${error.message}`);
       if (!cancelled) {
         this.logger.error(`Job ${job.id} failed: ${error.message}`, error.stack);
@@ -181,7 +190,11 @@ export class DubbingProcessor extends WorkerHost {
         });
       }
       try {
-        await this.updateJob(projectId, { status: 'failed', error_message: error.message?.slice(0, 5000) });
+        await this.updateJob(projectId, {
+          status: 'failed',
+          error_message: error.message?.slice(0, 5000),
+          credits_consumed: 0,
+        });
       } catch (updateError: any) {
         this.logger.error(
           `Job ${job.id}: failed to persist failed status for dub ${projectId}: ${updateError?.message}`,
@@ -189,6 +202,56 @@ export class DubbingProcessor extends WorkerHost {
         );
       }
       throw error;
+    }
+  }
+
+  /**
+   * Bring the amount already deducted in line with what the dub actually costs at the
+   * vendor's own duration, and return the new figure.
+   *
+   * Charging more can fail (the user may not hold the difference) — and it must fail the
+   * job rather than deliver, because this runs before the dub is handed over. Refunding
+   * the difference cannot fail in a way worth stopping for.
+   */
+  private async settleCredits(
+    userId: string,
+    charged: number,
+    actualDurationSeconds: number,
+    job: Job<DubJobData>,
+  ): Promise<number> {
+    const multiplier = this.getEnvNumber('DUBBING_CREDIT_MULTIPLIER', DUBBING_CREDIT_MULTIPLIER);
+    const owed = calculateDubbingCreditsByDuration(actualDurationSeconds, multiplier);
+    const delta = owed - charged;
+    if (delta === 0) return owed;
+
+    if (delta > 0) {
+      const { error } = await this.supabase.rpc('update_user_credits', {
+        user_uuid: userId,
+        credit_change: -delta,
+      });
+      if (error) {
+        throw new Error(
+          `This clip is ${Math.round(actualDurationSeconds)}s and costs ${owed} credits — that is more than your balance covers. Top up or trim the clip.`,
+        );
+      }
+      await job.log(`Clip measured ${Math.round(actualDurationSeconds)}s — ${delta} more credits charged.`);
+      return owed;
+    }
+
+    await this.refundCredits(userId, -delta);
+    await job.log(`Clip measured ${Math.round(actualDurationSeconds)}s — ${-delta} credits returned.`);
+    return owed;
+  }
+
+  /** Give credits back. Never throws: a failed refund must not mask the original error. */
+  private async refundCredits(userId: string, credits: number): Promise<void> {
+    if (credits <= 0) return;
+    const { error } = await this.supabase.rpc('update_user_credits', {
+      user_uuid: userId,
+      credit_change: credits,
+    });
+    if (error) {
+      this.logger.error(`Failed to refund ${credits} credits to user ${userId}: ${error.message}`);
     }
   }
 


### PR DESCRIPTION
An audit of the dubbing pipeline — web hook → API → BullMQ → worker → ElevenLabs → GCS — turned up two problems that cost real money and a handful of edges that just fail badly. 13 of ~20 edge cases were already handled; this covers the rest.

## Money

**Price was set by the browser.** The worker validated ElevenLabs' `expected_duration_sec` against the plan cap but still charged on the client-supplied `durationSeconds`. Posting `durationSeconds: 1` with a 45-minute file on an uncapped plan bought ~$11 of ElevenLabs for 3 credits. Credits are now settled against the vendor's own reading before the dub is handed over; if the user can't cover the difference the job fails rather than delivering.

**Credits were deducted after the dub.** Two concurrent dubs both passed the precheck — the second completed at ElevenLabs, then failed to bill, so the user lost the result and we paid for it anyway. Credits are now reserved atomically at enqueue (`update_user_credits` is floored at zero in Postgres), so the second dub is rejected *before* ElevenLabs is called. The worker settles the reservation against the real duration or refunds it in full. Nothing can fail between a finished dub and the user having it.

Refunds are split so exactly one side ever runs: the API refunds a job it pulls off the queue, the worker refunds one it aborts.

## Storage

Uploads are signed into a `staging/` prefix and moved to their permanent path only once the job is accepted, so an abandoned upload expires via a one-day bucket lifecycle rule rather than sitting in a public bucket forever. Every rejection path now deletes the staged object — previously a rejected dub left up to 500MB behind. The affordability check also moved into `sign-upload`, so a short balance is caught before the upload rather than after it.

## Plan resolution

Signup never created the Starter `subscriptions` row; it was written lazily by the first `GET /billing/info`. Every plan lookup reads that table, so on a brand-new account `/dubbing/access` could win the race, see no plan, fail closed and show an upgrade wall to a user whose plan allows dubbing. A refresh "fixed" it, which is why it never reproduces.

Fixed in `handle_new_user()` rather than in dubbing's fallback — video generation and research limits read the same table and had the same exposure. Includes a backfill for existing accounts; the lazy insert in billing stays as a harmless safety net.

## Edges

- Job ids are random UUIDs instead of `dubbing-{userId}-{ms}`. The SSE status route is unauthenticated (EventSource can't send an Authorization header), so a guessable id let anyone holding a user id brute-force the millisecond and watch the job, including the resulting URL. **Other features using `createJobSSE` share this pattern and want the same treatment** — out of scope here.
- The plan's real length cap now shows in the upload zone and is enforced at file-select. Previously it advertised a generic "Max 500MB · 45 min" to everyone and rejected Starter users after they'd filled in the whole form.
- A duration of `Infinity` (header-less VBR/WebM) is rejected at the source with an actionable message. It used to serialise to `null` and come back as the confusing "Duration is required".
- Regenerate and delete refuse while a dub is in flight (double charge; status writes failing under a running worker).
- Cancelling an active job no longer claims it stopped when it may already be past its last checkpoint.
- Copy: "21 languages" → 29.

## Deploy notes

Two steps beyond the merge:

1. Run the migration.
2. Apply the lifecycle rule to the dubbing bucket — documented in `docs/dubbing-design.md` §9.1 step 4. **Until it exists, staged uploads accumulate instead of expiring.** Note `--lifecycle-file` replaces every rule on the bucket, so check the existing config first.

## Verification

`pnpm type-check` (web + api), `pnpm lint`, the 30-test `dubbing.service.spec.ts` suite (12 new tests covering reservation, refund split, staging cleanup and the in-flight guards), and `npx tsx packages/validations/src/consts/dubbing.check.ts` all pass.
